### PR TITLE
Fix: PullLayer and CompleteUpload for OCI conformance

### DIFF
--- a/registry/v2/blobs.go
+++ b/registry/v2/blobs.go
@@ -61,9 +61,7 @@ func (b *blobs) remove(repo string) {
 }
 
 func (b *blobs) HEAD(ctx echo.Context) error {
-
 	digest := ctx.Param("digest")
-
 	layerRef, err := b.registry.localCache.GetDigest(digest)
 	if err != nil {
 		details := echo.Map{


### PR DESCRIPTION
Signed-off-by: guacamole <gunjanwalecha@gmail.com>
- Removed headers from PullLayer which were causing the fail during OCI tests
- Updated the store.Update() function to overwrite the Manifest.config if the tag is duplicate
- Total of 57 cases are passing, 2 failed, 3 skipped, following the snapshot of same

<img width="1438" alt="Screenshot 2021-09-11 at 11 38 26 AM" src="https://user-images.githubusercontent.com/68041753/132938275-fd7b57cc-1efc-47e6-b45b-18c83eb6aa99.png">
