### PR TITLE
fix: removed int overflow vulnerability

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 FROM golang:alpine as build
-LABEL org.opencontainers.image.source = "https://github.com/jay-dee7/OpenRegistry"
+LABEL org.opencontainers.image.source = "https://github.com/containerish/OpenRegistry"
 
 WORKDIR /root/openregistry
 

--- a/conformance.vars
+++ b/conformance.vars
@@ -1,4 +1,4 @@
-OCI_ROOT_URL=http://192.168.0.121:5001
+OCI_ROOT_URL=http://0.0.0.0:5001
 OCI_NAMESPACE=johndoe/dummmy-server
 OCI_CROSSMOUNT_NAMESPACE=johndoe/dummmy-server-cross-mount
 OCI_USERNAME=johndoe


### PR DESCRIPTION
Wrapped the overflowing int with uint and restricted the numbers of layers within a manifest to be within math.MaxInt16

Signed-off-by: jay-dee7 <jasdeepsingh.uppal@gmail.com>