### PR TITLE
fix: github action for conformance

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -35,6 +35,7 @@ jobs:
           OCI_TEST_CONTENT_DISCOVERY: 1
           OCI_TEST_CONTENT_MANAGEMENT: 1
           OCI_HIDE_SKIPPED_WORKFLOWS: 1
+          OCI_CROSSMOUNT_NAMESPACE: ${{secrets.OPENREGISTRY_USERNAME}}/distribution-cross-mount
           OCI_DEBUG: 0
           OCI_DELETE_MANIFEST_BEFORE_BLOBS: 0
       - run: mkdir -p .out/ && mv {report.html,junit.xml} .out/

--- a/conformance.vars
+++ b/conformance.vars
@@ -1,4 +1,4 @@
-OCI_ROOT_URL=http://0.0.0.0:5001
+OCI_ROOT_URL=http://0.0.0.0:5000
 OCI_NAMESPACE=johndoe/dummmy-server
 OCI_CROSSMOUNT_NAMESPACE=johndoe/dummmy-server-cross-mount
 OCI_USERNAME=johndoe


### PR DESCRIPTION
This PR adds the `OCI_CROSSMOUNT_NAMESPACE` environment variable in the
github action config file. This enables us passing all the test cases.

Signed-off-by: jay-dee7 <jasdeepsingh.uppal@gmail.com>