### PR TITLE
chore: added golangci linter to improve code quality

### DIFF
--- a/golangci.yaml
+++ b/golangci.yaml
@@ -1,0 +1,25 @@
+run:
+  timeout: 30s
+
+skip-dirs:
+  - .go-skynet
+
+linters-settings:
+  cyclop:
+    max-complexity: 16
+
+lll:
+  line-length: 120
+  tab-width: 1
+
+linters:
+  enable:
+    - bodyclose
+    - cyclop
+    - gochecknoglobals
+    - goimports
+    - gosec
+    - lll
+    - nilerr
+    - noctx
+    - sqlclosecheck


### PR DESCRIPTION
Signed-off-by: guacamole <gunjanwalecha@gmail.com>
* Enabled following linters apart from default:
    - bodyclose
    - cyclop
    - gochecknoglobals
    - goimports
    - gosec
    - lll
    - nilerr
    - noctx
    - sqlclosecheck
    - staticcheck