### PR TITLE
chore: fixes failing linter github action

### DIFF
--- a/.github/workflows/golangci-lint.yaml
+++ b/.github/workflows/golangci-lint.yaml
@@ -7,8 +7,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+      - name: Make Mod Fix for Skynet Deps
+        run: make mod-fix
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v2
         with:
-          version: latest
+          version: v1.42.1
           args: --config golangci.yaml

--- a/golangci.yaml
+++ b/golangci.yaml
@@ -1,5 +1,5 @@
 run:
-  timeout: 30s
+  timeout: 2m
 
 skip-dirs:
   - .go-skynet


### PR DESCRIPTION
This PR pins the version for `golangci-lint` github action to `v1.42.1` which comes with  support for all the linters we use.

- Runs `make mod-fix` before running linters
- Increased the timeout for linters to `2m`

Signed-off-by: jay-dee7 <jasdeepsingh.uppal@gmail.com>