### PR TITLE
add: added api support for fetching registry images

### DIFF
--- a/router/router.go
+++ b/router/router.go
@@ -97,7 +97,6 @@ func RegisterNSRoutes(nsRouter *echo.Group, reg registry.Registry) {
 	/// mf/sha -> mf/latest
 	nsRouter.Add(http.MethodDelete, BlobsDigest, reg.DeleteLayer)
 	nsRouter.Add(http.MethodDelete, ManifestsReference, reg.DeleteTagOrManifest)
-
 }
 
 // Docker is used for Catalog api


### PR DESCRIPTION
- Added QueryMetaData in datastore to fetch images by namespace, usernames and image-name
- ListWithPrefix function provides similar functionality but when made changes in ListWithPrefix, the OCI conformance tests were failing 

Signed-off-by: guacamole <gunjanwalecha@gmail.com>