### PR TITLE
Add: Zerolog with FluentBit  Integration

### DIFF
--- a/cache/register_for_beta.go
+++ b/cache/register_for_beta.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"regexp"
 
+	"github.com/containerish/OpenRegistry/types"
 	"github.com/dgraph-io/badger/v3"
 	"github.com/labstack/echo/v4"
 )
@@ -101,6 +102,7 @@ func (ds *dataStore) RegisterForBeta(ctx echo.Context) error {
 func (ds *dataStore) GetAllEmail(ctx echo.Context) error {
 	bz, err := ds.Get([]byte("email"))
 	if err != nil && err != badger.ErrKeyNotFound {
+		ctx.Set(types.HttpEndpointErrorKey, err.Error())
 		return ctx.JSON(http.StatusInternalServerError, echo.Map{
 			"error": "couldn't get them all",
 		})

--- a/main.go
+++ b/main.go
@@ -47,6 +47,6 @@ func main() {
 		return
 	}
 
-	router.Register(e, reg, authSvc, localCache)
+	router.Register(cfg, e, reg, authSvc, localCache)
 	log.Fatal().Msgf("error starting server: %s\n", e.Start(cfg.Address()))
 }

--- a/telemetry/fluent-bit/fluent_bit.go
+++ b/telemetry/fluent-bit/fluent_bit.go
@@ -111,6 +111,7 @@ func (fb *fluentBit) retrier(logBytes []byte, id string) {
 	body := bytes.NewBuffer(logBytes)
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second*10)
 	defer cancel()
+
 	req, err := http.NewRequestWithContext(ctx, http.MethodPost, fb.config.LogConfig.Endpoint, body)
 	if err != nil {
 		fb.queueForRetry(logBytes)

--- a/telemetry/log.go
+++ b/telemetry/log.go
@@ -1,11 +1,20 @@
 package telemetry
 
 import (
+	"bytes"
+	"encoding/json"
+	"io"
 	"os"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
 
+	fluentbit "github.com/containerish/OpenRegistry/telemetry/fluent-bit"
+	"github.com/containerish/OpenRegistry/types"
 	"github.com/labstack/echo/v4"
-	"github.com/labstack/echo/v4/middleware"
 	"github.com/rs/zerolog"
+	"github.com/valyala/fasttemplate"
 )
 
 func SetupLogger() zerolog.Logger {
@@ -13,22 +22,131 @@ func SetupLogger() zerolog.Logger {
 	zerolog.SetGlobalLevel(zerolog.DebugLevel)
 
 	l := zerolog.New(os.Stdout)
-	l.With().Caller().Logger()
+	l = l.With().Caller().Logger()
 
 	return l
 }
 
-func EchoLogger() echo.MiddlewareFunc {
-	logFmt := `{"time":"${time_rfc3339_nano}","id":"${id}","remote_ip":"${remote_ip}",` +
-		`"host":"${host}","method":"${method}","uri":"${uri}","user_agent":"${user_agent}",` +
-		`"status":${status},"error":"${error}","latency":${latency},"latency_human":"${latency_human}"` +
-		`,"bytes_in":${bytes_in},"bytes_out":${bytes_out}}` + "\n"
+//nolint:cyclop // insane amount of complexity because of templating
+func ZerologMiddleware(baseLogger zerolog.Logger, fluentbitClient fluentbit.FluentBit) echo.MiddlewareFunc {
+	return func(hf echo.HandlerFunc) echo.HandlerFunc {
+		pool := &sync.Pool{
+			New: func() interface{} {
+				return bytes.NewBuffer(make([]byte, 256))
+			},
+		}
 
-	return middleware.LoggerWithConfig(middleware.LoggerConfig{
-		Skipper: func(echo.Context) bool {
-			return false
-		},
-		Format: logFmt,
-		Output: os.Stdout,
-	})
+		logFmt := `{"time":"${time_rfc3339}","request_id":"${request_id}","remote_ip":"${remote_ip}",` +
+			`"host":"${host}","method":"${method}","uri":"${uri}","user_agent":"${user_agent}",` +
+			`"status":${status},"error":"${error}","latency":${latency},"latency_human":"${latency_human}"` +
+			`,"bytes_in":${bytes_in},"bytes_out":${bytes_out}}` + "\n"
+
+		template := fasttemplate.New(logFmt, "${", "}")
+
+		return func(ctx echo.Context) (err error) {
+			buf := pool.Get().(*bytes.Buffer)
+			buf.Reset()
+			defer pool.Put(buf)
+
+			req := ctx.Request()
+			res := ctx.Response()
+			start := time.Now()
+			if err = hf(ctx); err != nil {
+				ctx.Error(err)
+			}
+			stop := time.Now()
+
+			var level zerolog.Level
+			if _, err = template.ExecuteFunc(buf, func(_ io.Writer, tag string) (int, error) {
+				switch tag {
+				case "time_rfc3339":
+					return buf.WriteString(time.Now().Format(time.RFC3339))
+				case "request_id":
+					id := req.Header.Get(echo.HeaderXRequestID)
+					if id == "" {
+						id = res.Header().Get(echo.HeaderXRequestID)
+					}
+					return buf.WriteString(id)
+				case "remote_ip":
+					return buf.WriteString(ctx.RealIP())
+				case "host":
+					return buf.WriteString(req.Host)
+				case "uri":
+					return buf.WriteString(req.RequestURI)
+				case "method":
+					return buf.WriteString(req.Method)
+				case "path":
+					p := req.URL.Path
+					if p == "" {
+						p = "/"
+					}
+					return buf.WriteString(p)
+				case "protocol":
+					return buf.WriteString(req.Proto)
+				case "referer":
+					return buf.WriteString(req.Referer())
+				case "user_agent":
+					return buf.WriteString(req.UserAgent())
+				case "status":
+					status := res.Status
+					level = zerolog.InfoLevel
+					switch {
+					case status >= 500:
+						level = zerolog.ErrorLevel
+					case status >= 400:
+						level = zerolog.WarnLevel
+					case status >= 300:
+						level = zerolog.ErrorLevel
+					}
+
+					return buf.WriteString(strconv.FormatInt(int64(status), 10))
+				case "error":
+					if err != nil {
+						// Error may contain invalid JSON e.g. `"`
+						b, _ := json.Marshal(err.Error())
+						b = b[1 : len(b)-1]
+						return buf.Write(b)
+					}
+
+					if ctxErr, ok := ctx.Get(types.HttpEndpointErrorKey).(string); ok {
+						return buf.WriteString(ctxErr)
+					}
+				case "latency":
+					l := stop.Sub(start)
+					return buf.WriteString(strconv.FormatInt(int64(l), 10))
+				case "latency_human":
+					return buf.WriteString(stop.Sub(start).String())
+				case "bytes_in":
+					cl := req.Header.Get(echo.HeaderContentLength)
+					if cl == "" {
+						cl = "0"
+					}
+					return buf.WriteString(cl)
+				case "bytes_out":
+					return buf.WriteString(strconv.FormatInt(res.Size, 10))
+				default:
+					switch {
+					case strings.HasPrefix(tag, "header:"):
+						return buf.Write([]byte(ctx.Request().Header.Get(tag[7:])))
+					case strings.HasPrefix(tag, "query:"):
+						return buf.Write([]byte(ctx.QueryParam(tag[6:])))
+					case strings.HasPrefix(tag, "form:"):
+						return buf.Write([]byte(ctx.FormValue(tag[5:])))
+					case strings.HasPrefix(tag, "cookie:"):
+						if cookie, cookieErr := ctx.Cookie(tag[7:]); cookieErr == nil {
+							return buf.Write([]byte(cookie.Value))
+						}
+					}
+				}
+				return 0, nil
+			}); err != nil {
+				return
+			}
+
+			event := baseLogger.WithLevel(level).RawJSON("msg", buf.Bytes())
+			event.Send()
+			fluentbitClient.Send(buf.Bytes())
+			return
+		}
+	}
 }

--- a/types/app_error_keys.go
+++ b/types/app_error_keys.go
@@ -1,0 +1,5 @@
+package types
+
+const (
+	HttpEndpointErrorKey = "HTTP_ERROR"
+)

--- a/types/types.go
+++ b/types/types.go
@@ -18,27 +18,27 @@ type (
 	}
 
 	ImageManifest struct {
-		SchemaVersion int       `json:"schemaVersion"`
 		MediaType     string    `json:"mediaType"`
 		Layers        []*Layer  `json:"layers"`
 		Config        []*Config `json:"config"`
+		SchemaVersion int       `json:"schemaVersion"`
 	}
 
 	Blob struct {
-		RangeStart uint32
-		RangeEnd   uint32
 		Digest     string
 		Skylink    string
 		UUID       string
+		RangeStart uint32
+		RangeEnd   uint32
 	}
 
 	Layer struct {
 		MediaType  string `json:"mediaType"`
-		Blobs      []Blob `json:"blobs"`
-		Size       int    `json:"size"`
 		Digest     string `json:"digest"`
 		SkynetLink string `json:"skynetLink"`
 		UUID       string `json:"uuid"`
+		Blobs      []Blob `json:"blobs"`
+		Size       int    `json:"size"`
 	}
 
 	LayerRef struct {
@@ -48,10 +48,10 @@ type (
 
 	Config struct {
 		MediaType  string `json:"mediaType"`
-		Size       int    `json:"size"`
 		Digest     string `json:"digest"`
 		SkynetLink string `json:"skynetLink"`
 		Reference  string `json:"reference"`
+		Size       int    `json:"size"`
 	}
 )
 


### PR DESCRIPTION
This PR adds support for using a remote log aggregator using FluentBit.
FluentBit configuration is out of scope for this repo, but we do have a
sample configuration for it. We're currently using JSON formatted logs
with the following template:

```json
{"time":"${time_rfc3339}","request_id":"${request_id}","remote_ip":"${remote_ip}","host":"${host}","method":"${method}","uri":"${uri}","user_agent":"${user_agent}","status":"${status}","error":"${error}","latency":"${latency}","latency_human":"${latency_human}","bytes_in":"${bytes_in}","bytes_out":"${bytes_out}"}
```

Fields Included for logs (For all HTTP requests):
- Timestamp
- RequestID
- RemoteIP
- Host
- Method
- URI
- User Agent
- Status
- Error
- Latency
- Human Latency
- Bytes In
- Bytes Out

If we need, we can add more fields in the future and also connect with a
different log provider mechanism.

Signed-off-by: jay-dee7 <jasdeepsingh.uppal@gmail.com>