### PR TITLE
Feat: offloading bandwidth to client side for Pull operations

### DIFF
--- a/.github/workflows/conformance.yml
+++ b/.github/workflows/conformance.yml
@@ -26,7 +26,7 @@ jobs:
           sleep 5
           curl -XPOST -d ${{ secrets.OPENREGISTRY_SIGNUP_PAYLOAD }} "http://${IP}:5000/auth/signup"
       - name: Run OCI Distribution Spec conformance tests
-        uses: opencontainers/distribution-spec@main
+        uses: opencontainers/distribution-spec@v1.0.1
         env:
           OCI_ROOT_URL: ${{ env.OCI_ROOT_URL }}
           OCI_USERNAME: ${{ secrets.OPENREGISTRY_USERNAME }}

--- a/registry/v2/registry.go
+++ b/registry/v2/registry.go
@@ -550,10 +550,11 @@ func (r *registry) PullLayer(ctx echo.Context) error {
 		}
 	}
 
-	_, ok := r.skynet.Metadata(layerRef.Skylink)
+	size, ok := r.skynet.Metadata(layerRef.Skylink)
 	if ok {
 		url := fmt.Sprintf("https://siasky.net/%s",
 			strings.Replace(layerRef.Skylink, "sia://", "", 1))
+		ctx.Response().Header().Set("Content-Length", fmt.Sprintf("%d", size))
 		http.Redirect(ctx.Response(), ctx.Request(), url, http.StatusTemporaryRedirect)
 		return nil
 	}

--- a/telemetry/fluent-bit/fluent_bit.go
+++ b/telemetry/fluent-bit/fluent_bit.go
@@ -46,7 +46,11 @@ func New(config *config.RegistryConfig) (FluentBit, error) {
 
 func (fb *fluentBit) Send(logBytes []byte) {
 	// don't send logs to grafana from local instances of OpenRegistry
-	if fb.config.Environment == config.Dev || fb.config.Environment == config.Local {
+	dev := fb.config.Environment == config.Dev
+	local := fb.config.Environment == config.Local
+	ci := fb.config.Environment == config.CI
+
+	if dev || local || ci {
 		return
 	}
 


### PR DESCRIPTION
- Redirecting the Pull operations to offload bandwidth to client side
- For OCI conformance, one of the tests is failing and is being tracked by following issues in OpenContainers:
    * https://github.com/opencontainers/distribution-spec/issues/299
    * https://github.com/opencontainers/distribution-spec/issues/234


Signed-off-by: guacamole <gunjanwalecha@gmail.com>