### PR TITLE
Fix: Use our fork of go-skynet for all Skynet Ops

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,18 +3,19 @@ module github.com/containerish/OpenRegistry
 go 1.17
 
 require (
-	github.com/NebulousLabs/go-skynet/v2 v2.0.2
+	github.com/SkynetLabs/go-skynet/v2 v2.0.2
 	github.com/dgraph-io/badger/v3 v3.2103.1
 	github.com/docker/distribution v2.7.1+incompatible
 	github.com/fatih/color v1.12.0
 	github.com/golang-jwt/jwt v3.2.2+incompatible
+	github.com/google/uuid v1.3.0
 	github.com/labstack/echo-contrib v0.11.0
 	github.com/labstack/echo/v4 v4.5.0
 	github.com/rs/zerolog v1.24.0
 	github.com/spf13/viper v1.8.1
+	github.com/valyala/fasttemplate v1.2.1
 	github.com/whyrusleeping/tar-utils v0.0.0-20201201191210-20a61371de5b
 	golang.org/x/crypto v0.0.0-20210817164053-32db794688a5
-    github.com/google/uuid v1.3.0
 )
 
 require (
@@ -50,7 +51,6 @@ require (
 	github.com/spf13/pflag v1.0.5 // indirect
 	github.com/subosito/gotenv v1.2.0 // indirect
 	github.com/valyala/bytebufferpool v1.0.0 // indirect
-	github.com/valyala/fasttemplate v1.2.1 // indirect
 	gitlab.com/NebulousLabs/errors v0.0.0-20171229012116-7ead97ef90b8 // indirect
 	go.opencensus.io v0.23.0 // indirect
 	golang.org/x/net v0.0.0-20210405180319-a5a99cb37ef4 // indirect
@@ -62,4 +62,4 @@ require (
 	gopkg.in/yaml.v2 v2.4.0 // indirect
 )
 
-replace github.com/NebulousLabs/go-skynet/v2 => ./.go-skynet
+replace github.com/SkynetLabs/go-skynet/v2 => github.com/containerish/go-skynet/v2 v2.0.2-0.20211205085848-1bbf98d18f7c

--- a/go.sum
+++ b/go.sum
@@ -90,6 +90,8 @@ github.com/cncf/udpa/go v0.0.0-20200629203442-efcf912fb354/go.mod h1:WmhPx2Nbnht
 github.com/cncf/udpa/go v0.0.0-20201120205902-5459f2c99403/go.mod h1:WmhPx2Nbnhtbo57+VJT5O0JRkEi1Wbu0z5j0R8u5Hbk=
 github.com/cockroachdb/datadriven v0.0.0-20190809214429-80d97fb3cbaa/go.mod h1:zn76sxSg3SzpJ0PPJaLDCu+Bu0Lg3sKTORVIj19EIF8=
 github.com/codahale/hdrhistogram v0.0.0-20161010025455-3a0bb77429bd/go.mod h1:sE/e/2PUdi/liOCUjSTXgM1o87ZssimdTWN964YiIeI=
+github.com/containerish/go-skynet/v2 v2.0.2-0.20211205085848-1bbf98d18f7c h1:RHWAHjh7/wBuXnc/B4+tNoV9JMHiH7Wlp45vEttWd1o=
+github.com/containerish/go-skynet/v2 v2.0.2-0.20211205085848-1bbf98d18f7c/go.mod h1:XOk0zwGlXeGjHQgmhXTEk7qTD6FVv3dXPW38Wh3XsIc=
 github.com/coreos/etcd v3.3.10+incompatible/go.mod h1:uF7uidLiAD3TWHmW31ZFd/JWoc32PjwdhPthX9715RE=
 github.com/coreos/go-etcd v2.0.0+incompatible/go.mod h1:Jez6KQU2B/sWsbdaef3ED8NzMklzPG4d5KIOhIy30Tk=
 github.com/coreos/go-semver v0.2.0/go.mod h1:nnelYz7RCh+5ahJtPPxZlU+153eP4D4r3EedlOD2RNk=

--- a/skynet/skynet.go
+++ b/skynet/skynet.go
@@ -6,7 +6,7 @@ import (
 	"log"
 	"strconv"
 
-	"github.com/NebulousLabs/go-skynet/v2"
+	"github.com/SkynetLabs/go-skynet/v2"
 	"github.com/containerish/OpenRegistry/config"
 	tar "github.com/whyrusleeping/tar-utils"
 )

--- a/skynet/types.go
+++ b/skynet/types.go
@@ -5,7 +5,7 @@ import (
 	"encoding/json"
 	"io"
 
-	skynet "github.com/NebulousLabs/go-skynet/v2"
+	skynet "github.com/SkynetLabs/go-skynet/v2"
 )
 
 type (


### PR DESCRIPTION
Fixes #79 - from here on we use our fork of skynet maintained at
[Containerish's Fork of Skynet Go SDK](https://github.com/containerish/go-skynet.git)

Signed-off-by: jay-dee7 <jasdeepsingh.uppal@gmail.com>