### PR TITLE
Fix: logging by adding new logger struct

### DIFF
--- a/auth/auth.go
+++ b/auth/auth.go
@@ -3,6 +3,7 @@ package auth
 import (
 	"github.com/containerish/OpenRegistry/cache"
 	"github.com/containerish/OpenRegistry/config"
+	"github.com/containerish/OpenRegistry/telemetry"
 	"github.com/labstack/echo/v4"
 )
 
@@ -17,12 +18,13 @@ type Authentication interface {
 }
 
 type auth struct {
-	store cache.Store
-	c     *config.RegistryConfig
+	store  cache.Store
+	c      *config.RegistryConfig
+	logger telemetry.Logger
 }
 
 // New is the constructor function returns an Authentication implementation
-func New(s cache.Store, c *config.RegistryConfig) Authentication {
-	a := &auth{store: s, c: c}
+func New(s cache.Store, c *config.RegistryConfig, logger telemetry.Logger) Authentication {
+	a := &auth{store: s, c: c, logger: logger}
 	return a
 }

--- a/auth/basic_auth.go
+++ b/auth/basic_auth.go
@@ -4,13 +4,12 @@ import (
 	// "fmt"
 	"encoding/base64"
 	"fmt"
-	"net/http"
-	"strconv"
-	"strings"
-
 	"github.com/containerish/OpenRegistry/registry/v2"
 	"github.com/labstack/echo/v4"
 	"github.com/labstack/echo/v4/middleware"
+	"net/http"
+	"strconv"
+	"strings"
 )
 
 const (

--- a/auth/basic_auth.go
+++ b/auth/basic_auth.go
@@ -4,12 +4,15 @@ import (
 	// "fmt"
 	"encoding/base64"
 	"fmt"
-	"github.com/containerish/OpenRegistry/registry/v2"
-	"github.com/labstack/echo/v4"
-	"github.com/labstack/echo/v4/middleware"
 	"net/http"
 	"strconv"
 	"strings"
+	"time"
+
+	"github.com/containerish/OpenRegistry/registry/v2"
+	"github.com/containerish/OpenRegistry/types"
+	"github.com/labstack/echo/v4"
+	"github.com/labstack/echo/v4/middleware"
 )
 
 const (
@@ -58,17 +61,26 @@ func (a *auth) BasicAuth() echo.MiddlewareFunc {
 			return false
 		},
 		Validator: func(username string, password string, ctx echo.Context) (bool, error) {
+			ctx.Set(types.HandlerStartTime, time.Now())
+			printInMiddleware := true
+			defer func() {
+				if printInMiddleware {
+					a.logger.Log(ctx).Send()
+				}
+			}()
+
 			if ctx.Request().RequestURI == "/v2/" {
 				_, err := a.validateUser(username, password)
 				if err != nil {
+					ctx.Set(types.HttpEndpointErrorKey, err.Error())
 					return false, ctx.NoContent(http.StatusUnauthorized)
 				}
 
+				printInMiddleware = false
 				return true, nil
 			}
 
 			usernameFromNameSpace := ctx.Param("username")
-
 			if usernameFromNameSpace != username {
 				var errMsg registry.RegistryErrors
 				errMsg.Errors = append(errMsg.Errors, registry.RegistryError{
@@ -76,13 +88,16 @@ func (a *auth) BasicAuth() echo.MiddlewareFunc {
 					Message: "not authorised",
 					Detail:  nil,
 				})
+				ctx.Set(types.HttpEndpointErrorKey, errMsg)
 				return false, ctx.JSON(http.StatusForbidden, errMsg)
 			}
 			resp, err := a.validateUser(username, password)
 			if err != nil {
+				ctx.Set(types.HttpEndpointErrorKey, err.Error())
 				return false, err
 			}
 
+			printInMiddleware = false
 			ctx.Set("basic_auth", resp)
 			return true, nil
 		},

--- a/auth/jwt_middleware.go
+++ b/auth/jwt_middleware.go
@@ -2,7 +2,9 @@ package auth
 
 import (
 	"net/http"
+	"time"
 
+	"github.com/containerish/OpenRegistry/types"
 	"github.com/golang-jwt/jwt"
 	"github.com/labstack/echo/v4"
 	"github.com/labstack/echo/v4/middleware"
@@ -24,16 +26,22 @@ func (a *auth) JWT() echo.MiddlewareFunc {
 
 			return true
 		},
-		BeforeFunc:              middleware.DefaultJWTConfig.BeforeFunc,
-		SuccessHandler:          middleware.DefaultJWTConfig.SuccessHandler,
-		ErrorHandler:            middleware.DefaultJWTConfig.ErrorHandler,
-		ErrorHandlerWithContext: middleware.DefaultJWTConfig.ErrorHandlerWithContext,
-		KeyFunc:                 middleware.DefaultJWTConfig.KeyFunc,
-		ParseTokenFunc:          middleware.DefaultJWTConfig.ParseTokenFunc,
-		SigningKey:              []byte(a.c.SigningSecret),
-		SigningKeys:             map[string]interface{}{},
-		SigningMethod:           jwt.SigningMethodHS256.Name,
-		Claims:                  &Claims{},
+		BeforeFunc:     middleware.DefaultJWTConfig.BeforeFunc,
+		SuccessHandler: middleware.DefaultJWTConfig.SuccessHandler,
+		ErrorHandler:   middleware.DefaultJWTConfig.ErrorHandler,
+		ErrorHandlerWithContext: func(err error, ctx echo.Context) error {
+			// ErrorHandlerWithContext only logs the failing requtest
+			ctx.Set(types.HandlerStartTime, time.Now())
+			ctx.Set(types.HttpEndpointErrorKey, err.Error())
+			a.logger.Log(ctx)
+			return ctx.NoContent(http.StatusUnauthorized)
+		},
+		KeyFunc:        middleware.DefaultJWTConfig.KeyFunc,
+		ParseTokenFunc: middleware.DefaultJWTConfig.ParseTokenFunc,
+		SigningKey:     []byte(a.c.SigningSecret),
+		SigningKeys:    map[string]interface{}{},
+		SigningMethod:  jwt.SigningMethodHS256.Name,
+		Claims:         &Claims{},
 	})
 }
 
@@ -41,6 +49,11 @@ func (a *auth) JWT() echo.MiddlewareFunc {
 func (a *auth) ACL() echo.MiddlewareFunc {
 	return func(hf echo.HandlerFunc) echo.HandlerFunc {
 		return func(ctx echo.Context) error {
+			ctx.Set(types.HandlerStartTime, time.Now())
+			defer func() {
+				a.logger.Log(ctx)
+			}()
+
 			m := ctx.Request().Method
 			if m == http.MethodGet || m == http.MethodHead {
 				return hf(ctx)
@@ -48,11 +61,13 @@ func (a *auth) ACL() echo.MiddlewareFunc {
 
 			token, ok := ctx.Get("user").(*jwt.Token)
 			if !ok {
+				ctx.Set(types.HttpEndpointErrorKey, "ACL: unauthorized")
 				return ctx.NoContent(http.StatusUnauthorized)
 			}
 
 			claims, ok := token.Claims.(*Claims)
 			if !ok {
+				ctx.Set(types.HttpEndpointErrorKey, "ACL: invalid claims")
 				return ctx.NoContent(http.StatusUnauthorized)
 			}
 
@@ -61,6 +76,7 @@ func (a *auth) ACL() echo.MiddlewareFunc {
 				return hf(ctx)
 			}
 
+			ctx.Set(types.HttpEndpointErrorKey, "ACL: username didn't match from token")
 			return ctx.NoContent(http.StatusUnauthorized)
 		}
 	}

--- a/auth/signin.go
+++ b/auth/signin.go
@@ -6,10 +6,15 @@ import (
 	"net/http"
 	"time"
 
+	"github.com/containerish/OpenRegistry/types"
 	"github.com/labstack/echo/v4"
 )
 
 func (a *auth) SignIn(ctx echo.Context) error {
+	ctx.Set(types.HandlerStartTime, time.Now())
+	defer func() {
+		a.logger.Log(ctx).Send()
+	}()
 	var user User
 
 	if err := json.NewDecoder(ctx.Request().Body).Decode(&user); err != nil {
@@ -18,21 +23,26 @@ func (a *auth) SignIn(ctx echo.Context) error {
 		})
 	}
 	if user.Email == "" && user.Username == "" {
-		return ctx.JSON(http.StatusBadRequest, echo.Map{
+		errMsg := echo.Map{
 			"error": "email and username cannot be empty, please provide at least one of them",
-		})
+		}
+		ctx.Set(types.HttpEndpointErrorKey, errMsg)
+		return ctx.JSON(http.StatusBadRequest, errMsg)
 	}
 
 	if user.Password == "" {
-		return ctx.JSON(http.StatusBadRequest, echo.Map{
+		errMsg := echo.Map{
 			"error": "password cannot be empty",
-		})
+		}
+		ctx.Set(types.HttpEndpointErrorKey, errMsg)
+		return ctx.JSON(http.StatusBadRequest, errMsg)
 	}
 
 	var key string
 
 	if user.Email != "" {
 		if err := verifyEmail(user.Email); err != nil {
+			ctx.Set(types.HttpEndpointErrorKey, err.Error())
 			return ctx.JSON(http.StatusBadRequest, echo.Map{
 				"error": err.Error(),
 			})
@@ -44,6 +54,7 @@ func (a *auth) SignIn(ctx echo.Context) error {
 
 	bz, err := a.store.Get([]byte(key))
 	if err != nil {
+		ctx.Set(types.HttpEndpointErrorKey, err.Error())
 		return ctx.JSON(http.StatusBadRequest, echo.Map{
 			"error": err.Error(),
 		})
@@ -51,20 +62,22 @@ func (a *auth) SignIn(ctx echo.Context) error {
 
 	var userFromDb User
 	if err := json.Unmarshal(bz, &userFromDb); err != nil {
+		ctx.Set(types.HttpEndpointErrorKey, err.Error())
 		return ctx.JSON(http.StatusInternalServerError, echo.Map{
 			"error": err.Error(),
 		})
 	}
 
 	if !a.verifyPassword(userFromDb.Password, user.Password) {
-		return ctx.JSON(http.StatusUnauthorized, echo.Map{
-			"error": "invalid password",
-		})
+		errMsg := "invalid password"
+		ctx.Set(types.HttpEndpointErrorKey, errMsg)
+		return ctx.JSON(http.StatusUnauthorized, errMsg)
 	}
 
 	tokenLife := time.Now().Add(time.Hour * 24 * 14).Unix()
 	token, err := a.newToken(userFromDb, tokenLife)
 	if err != nil {
+		ctx.Set(types.HttpEndpointErrorKey, err.Error())
 		return ctx.JSON(http.StatusInternalServerError, echo.Map{
 			"error": err.Error(),
 		})

--- a/auth/signup.go
+++ b/auth/signup.go
@@ -44,7 +44,6 @@ func (u *User) Validate(store cache.Store) error {
 
 	if bz != nil {
 		var userList []User
-		fmt.Printf("%s\n", bz)
 		if err := json.Unmarshal(bz, &userList); err != nil {
 
 			if strings.Contains(err.Error(), "object into Go value of type []auth.User") {

--- a/auth/signup.go
+++ b/auth/signup.go
@@ -7,9 +7,11 @@ import (
 	"net/http"
 	"regexp"
 	"strings"
+	"time"
 	"unicode"
 
 	"github.com/containerish/OpenRegistry/cache"
+	"github.com/containerish/OpenRegistry/types"
 	"github.com/labstack/echo/v4"
 )
 
@@ -138,10 +140,15 @@ func verifyPassword(password string) error {
 }
 
 func (a *auth) SignUp(ctx echo.Context) error {
+	ctx.Set(types.HandlerStartTime, time.Now())
+	defer func() {
+		a.logger.Log(ctx).Send()
+	}()
 
 	var u User
 	bz, err := io.ReadAll(ctx.Request().Body)
 	if err != nil {
+		ctx.Set(types.HttpEndpointErrorKey, err.Error())
 		return ctx.JSON(http.StatusBadRequest, echo.Map{
 			"error": err.Error(),
 			"msg":   "invalid request body",
@@ -150,13 +157,14 @@ func (a *auth) SignUp(ctx echo.Context) error {
 	ctx.Request().Body.Close()
 
 	if err := json.Unmarshal(bz, &u); err != nil {
+		ctx.Set(types.HttpEndpointErrorKey, err.Error())
 		return ctx.JSON(http.StatusBadRequest, echo.Map{
 			"error": err.Error(),
-			"msg":   "couldn't marshal user",
 		})
 	}
 
 	if err := u.Validate(a.store); err != nil {
+		ctx.Set(types.HttpEndpointErrorKey, err.Error())
 		return ctx.JSON(http.StatusBadRequest, echo.Map{
 			"error": err.Error(),
 		})
@@ -164,6 +172,7 @@ func (a *auth) SignUp(ctx echo.Context) error {
 
 	hpwd, err := a.hashPassword(u.Password)
 	if err != nil {
+		ctx.Set(types.HttpEndpointErrorKey, err.Error())
 		return ctx.JSON(http.StatusInternalServerError, echo.Map{
 			"error": err.Error(),
 		})
@@ -171,6 +180,7 @@ func (a *auth) SignUp(ctx echo.Context) error {
 	u.Password = hpwd
 	bz, err = json.Marshal(u)
 	if err != nil {
+		ctx.Set(types.HttpEndpointErrorKey, err.Error())
 		return ctx.JSON(http.StatusInternalServerError, echo.Map{
 			"error": err.Error(),
 		})
@@ -178,6 +188,7 @@ func (a *auth) SignUp(ctx echo.Context) error {
 
 	key := fmt.Sprintf("%s/%s", UserNameSpace, u.Username)
 	if err := a.store.Set([]byte(key), bz); err != nil {
+		ctx.Set(types.HttpEndpointErrorKey, err.Error())
 		return ctx.JSON(http.StatusInternalServerError, echo.Map{
 			"error": err.Error(),
 		})
@@ -185,6 +196,7 @@ func (a *auth) SignUp(ctx echo.Context) error {
 
 	key = fmt.Sprintf("%s/%s", UserNameSpace, u.Email)
 	if err := a.store.Set([]byte(key), bz); err != nil {
+		ctx.Set(types.HttpEndpointErrorKey, err.Error())
 		return ctx.JSON(http.StatusInternalServerError, echo.Map{
 			"error": err.Error(),
 		})

--- a/main.go
+++ b/main.go
@@ -34,19 +34,19 @@ func main() {
 	authSvc := auth.New(localCache, cfg)
 	skynetClient := skynet.NewClient(cfg)
 
-	log := telemetry.SetupLogger()
 	fluentBitCollector, err := fluentbit.New(cfg)
 	if err != nil {
 		color.Red("error initializing fluentbit collector: %s\n", err)
 		os.Exit(1)
 	}
 
-	reg, err := registry.NewRegistry(skynetClient, log, localCache, e.Logger, fluentBitCollector)
+	logger := telemetry.ZLogger(telemetry.SetupLogger(), fluentBitCollector)
+	reg, err := registry.NewRegistry(skynetClient, localCache, logger)
 	if err != nil {
 		e.Logger.Errorf("error creating new container registry: %s", err)
 		return
 	}
 
 	router.Register(cfg, e, reg, authSvc, localCache)
-	log.Fatal().Msgf("error starting server: %s\n", e.Start(cfg.Address()))
+	logger.Errorf("error initialising OpenRegistry Server: %s", e.Start(cfg.Address()))
 }

--- a/main.go
+++ b/main.go
@@ -31,9 +31,6 @@ func main() {
 	}
 	defer localCache.Close()
 
-	authSvc := auth.New(localCache, cfg)
-	skynetClient := skynet.NewClient(cfg)
-
 	fluentBitCollector, err := fluentbit.New(cfg)
 	if err != nil {
 		color.Red("error initializing fluentbit collector: %s\n", err)
@@ -41,6 +38,9 @@ func main() {
 	}
 
 	logger := telemetry.ZLogger(telemetry.SetupLogger(), fluentBitCollector)
+	authSvc := auth.New(localCache, cfg, logger)
+	skynetClient := skynet.NewClient(cfg)
+
 	reg, err := registry.NewRegistry(skynetClient, localCache, logger)
 	if err != nil {
 		e.Logger.Errorf("error creating new container registry: %s", err)

--- a/registry/v2/helpers.go
+++ b/registry/v2/helpers.go
@@ -19,9 +19,7 @@ func (r *registry) errorResponse(code, msg string, detail map[string]interface{}
 
 	bz, e := json.Marshal(err)
 	if e != nil {
-		lm := make(logMsg)
-		lm["error"] = e.Error()
-		r.debugf(lm)
+		r.logger.Error(e.Error())
 	}
 
 	return bz
@@ -37,17 +35,17 @@ func digest(bz []byte) string {
 	return "sha256:" + hex.EncodeToString(hash.Sum(nil))
 }
 
-func (r *registry) debugf(lm logMsg) {
-
-	if r.debug {
-		r.echoLogger.Debug(lm)
-	}
-
-	if r.debug {
-		e := r.log.Debug()
-		e.Fields(lm).Send()
-	}
-}
+//func (r *registry) debugf(lm logMsg) {
+//
+//	if r.debug {
+//		r.echoLogger.Debug(lm)
+//	}
+//
+//	if r.debug {
+//		e := r.log.Debug()
+//		e.Fields(lm).Send()
+//	}
+//}
 
 func (r *registry) getHttpUrlFromSkylink(s string) string {
 	link := strings.TrimPrefix(s, "sia://")

--- a/registry/v2/registry.go
+++ b/registry/v2/registry.go
@@ -4,6 +4,8 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
+	"github.com/containerish/OpenRegistry/telemetry"
+	"github.com/labstack/gommon/color"
 	"io"
 	"net/http"
 	"path"
@@ -11,37 +13,31 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+	"time"
 
 	"github.com/containerish/OpenRegistry/cache"
 	"github.com/containerish/OpenRegistry/skynet"
-	fluentbit "github.com/containerish/OpenRegistry/telemetry/fluent-bit"
 	"github.com/containerish/OpenRegistry/types"
 	"github.com/docker/distribution/uuid"
 	"github.com/labstack/echo/v4"
-	"github.com/rs/zerolog"
 )
 
 func NewRegistry(
 	skynetClient *skynet.Client,
-	logger zerolog.Logger,
 	c cache.Store,
-	echoLogger echo.Logger,
-	fluentBit fluentbit.FluentBit,
+	logger telemetry.Logger,
 ) (Registry, error) {
 	r := &registry{
-		log:       logger,
-		debug:     true,
-		fluentbit: fluentBit,
-		skynet:    skynetClient,
+		debug:  true,
+		skynet: skynetClient,
 		b: blobs{
-			mutex:     sync.Mutex{},
-			contents:  map[string][]byte{},
-			uploads:   map[string][]byte{},
-			layers:    map[string][]string{},
-			fluentbit: fluentBit,
+			mutex:    sync.Mutex{},
+			contents: map[string][]byte{},
+			uploads:  map[string][]byte{},
+			layers:   map[string][]string{},
 		},
 		localCache: c,
-		echoLogger: echoLogger,
+		logger:     logger,
 		mu:         &sync.RWMutex{},
 	}
 
@@ -53,6 +49,12 @@ func NewRegistry(
 // Catalog - The list of available repositories is made available through the catalog.
 //GET /v2/_catalog
 func (r *registry) Catalog(ctx echo.Context) error {
+	ctx.Set(types.HandlerStartTime, time.Now())
+	defer func() {
+		color.Red("klsjdkskdlskdls")
+		r.logger.Log(ctx).Send()
+	}()
+
 	bz, err := r.localCache.ListAll()
 	if err != nil {
 		logMsg := echo.Map{
@@ -91,6 +93,11 @@ func (r *registry) Catalog(ctx echo.Context) error {
 }
 
 func (r *registry) DeleteTagOrManifest(ctx echo.Context) error {
+	start := time.Now()
+	defer func() {
+		r.logger.Log(ctx).Send()
+	}()
+
 	namespace := ctx.Param("username") + "/" + ctx.Param("imagename")
 	ref := ctx.Param("reference")
 
@@ -108,13 +115,20 @@ func (r *registry) DeleteTagOrManifest(ctx echo.Context) error {
 		}
 		errMsg := r.errorResponse(RegistryErrorCodeManifestUnknown, err.Error(), details)
 		ctx.Set(types.HttpEndpointErrorKey, errMsg)
+		ctx.Set(types.HandlerStartTime, start)
 		return ctx.JSONBlob(http.StatusNotFound, errMsg)
 	}
-
+	ctx.Set(types.HandlerStartTime, start)
 	return ctx.NoContent(http.StatusAccepted)
 }
 
 func (r *registry) DeleteLayer(ctx echo.Context) error {
+
+	start := time.Now()
+	defer func() {
+		r.logger.Log(ctx).Send()
+	}()
+
 	namespace := ctx.Param("username") + "/" + ctx.Param("imagename")
 	dig := ctx.Param("digest")
 
@@ -124,12 +138,16 @@ func (r *registry) DeleteLayer(ctx echo.Context) error {
 		bz, err := r.localCache.Get([]byte(namespace))
 		if err != nil {
 			errMsg := r.errorResponse(RegistryErrorCodeBlobUnknown, err.Error(), nil)
+			err = ctx.JSONBlob(http.StatusNotFound, errMsg)
+
 			ctx.Set(types.HttpEndpointErrorKey, errMsg)
-			return ctx.JSONBlob(http.StatusNotFound, errMsg)
+			ctx.Set(types.HandlerStartTime, start)
+			return err
 		}
 		if err = json.Unmarshal(bz, &m); err != nil {
 			errMsg := r.errorResponse(RegistryErrorCodeBlobUnknown, err.Error(), nil)
 			ctx.Set(types.HttpEndpointErrorKey, errMsg)
+			ctx.Set(types.HandlerStartTime, start)
 			return ctx.JSONBlob(http.StatusInternalServerError, errMsg)
 		}
 	}
@@ -143,9 +161,10 @@ func (r *registry) DeleteLayer(ctx echo.Context) error {
 
 		bz, err := json.Marshal(logMsg)
 		if err == nil {
+			ctx.Set(types.HandlerStartTime, start)
 			ctx.Set(types.HttpEndpointErrorKey, logMsg)
 		}
-
+		ctx.Set(types.HandlerStartTime, start)
 		return ctx.JSONBlob(http.StatusInternalServerError, bz)
 	}
 
@@ -158,17 +177,24 @@ func (r *registry) DeleteLayer(ctx echo.Context) error {
 		ctx.Set(types.HttpEndpointErrorKey, logMsg)
 		bz, err := json.Marshal(logMsg)
 		if err != nil {
-			r.log.Err(err).Send()
+			ctx.Set(types.HttpEndpointErrorKey, err.Error())
+			ctx.Set(types.HandlerStartTime, start)
+			r.logger.Log(ctx)
 		}
-
+		ctx.Set(types.HandlerStartTime, start)
 		return ctx.JSONBlob(http.StatusInternalServerError, bz)
 	}
-
+	ctx.Set(types.HandlerStartTime, start)
 	return ctx.NoContent(http.StatusAccepted)
 }
 
 // PUT /v2/<name>/blobs/uploads/<uuid>?digest=<digest>
 func (r *registry) MonolithicUpload(ctx echo.Context) error {
+	start := time.Now()
+	defer func() {
+		r.logger.Log(ctx).Send()
+	}()
+
 	namespace := ctx.Param("username") + "/" + ctx.Param("imagename")
 	uuid := ctx.Param("uuid")
 	digest := ctx.QueryParam("digest")
@@ -177,6 +203,7 @@ func (r *registry) MonolithicUpload(ctx echo.Context) error {
 	if err != nil {
 		errMsg := r.errorResponse(RegistryErrorCodeBlobUploadInvalid, err.Error(), nil)
 		ctx.Set(types.HttpEndpointErrorKey, errMsg)
+		ctx.Set(types.HandlerStartTime, start)
 		return ctx.JSONBlob(http.StatusBadRequest, errMsg)
 	}
 	ctx.Request().Body.Close()
@@ -189,6 +216,7 @@ func (r *registry) MonolithicUpload(ctx echo.Context) error {
 		}
 		errMsg := r.errorResponse(RegistryErrorCodeBlobUploadInvalid, err.Error(), detail)
 		ctx.Set(types.HttpEndpointErrorKey, errMsg)
+		ctx.Set(types.HandlerStartTime, start)
 		return ctx.JSONBlob(http.StatusInternalServerError, bz)
 	}
 
@@ -205,16 +233,23 @@ func (r *registry) MonolithicUpload(ctx echo.Context) error {
 	if err != nil {
 		errMsg := r.errorResponse(RegistryErrorCodeBlobUploadInvalid, err.Error(), nil)
 		ctx.Set(types.HttpEndpointErrorKey, errMsg)
+		ctx.Set(types.HandlerStartTime, start)
 		return ctx.JSONBlob(http.StatusBadRequest, errMsg)
 	}
 
 	locationHeader := link
 	ctx.Response().Header().Set("Location", locationHeader)
+	ctx.Set(types.HandlerStartTime, start)
 	return ctx.NoContent(http.StatusCreated)
 }
 
 // PUT /v2/<name>/blobs/uploads/<uuid>?digest=<digest>
 func (r *registry) CompleteUpload(ctx echo.Context) error {
+	start := time.Now()
+	defer func() {
+		r.logger.Log(ctx).Send()
+	}()
+
 	dig := ctx.QueryParam("digest")
 	namespace := ctx.Param("username") + "/" + ctx.Param("imagename")
 	uuid := ctx.Param("uuid")
@@ -223,6 +258,7 @@ func (r *registry) CompleteUpload(ctx echo.Context) error {
 	if err != nil {
 		errMsg := r.errorResponse(RegistryErrorCodeDigestInvalid, err.Error(), nil)
 		ctx.Set(types.HttpEndpointErrorKey, errMsg)
+		ctx.Set(types.HandlerStartTime, start)
 		return ctx.JSONBlob(http.StatusBadRequest, errMsg)
 	}
 	_ = ctx.Request().Body.Close()
@@ -238,6 +274,7 @@ func (r *registry) CompleteUpload(ctx echo.Context) error {
 		}
 		errMsg := r.errorResponse(RegistryErrorCodeDigestInvalid, "digest mismatch", details)
 		ctx.Set(types.HttpEndpointErrorKey, errMsg)
+		ctx.Set(types.HandlerStartTime, start)
 		return ctx.JSONBlob(http.StatusBadRequest, errMsg)
 	}
 
@@ -246,11 +283,13 @@ func (r *registry) CompleteUpload(ctx echo.Context) error {
 	if err != nil {
 		errMsg := r.errorResponse(RegistryErrorCodeBlobUploadInvalid, err.Error(), nil)
 		ctx.Set(types.HttpEndpointErrorKey, errMsg)
+		ctx.Set(types.HandlerStartTime, start)
 		return ctx.JSONBlob(http.StatusRequestedRangeNotSatisfiable, errMsg)
 	}
 	if err := r.localCache.SetDigest(ourHash, skylink); err != nil {
 		errMsg := r.errorResponse(RegistryErrorCodeBlobUnknown, err.Error(), nil)
 		ctx.Set(types.HttpEndpointErrorKey, errMsg)
+		ctx.Set(types.HandlerStartTime, start)
 		return ctx.JSONBlob(http.StatusInternalServerError, errMsg)
 	}
 
@@ -270,6 +309,7 @@ func (r *registry) CompleteUpload(ctx echo.Context) error {
 	if err = r.localCache.Update([]byte(namespace), val.Bytes()); err != nil {
 		errMsg := r.errorResponse(RegistryErrorCodeUnsupported, err.Error(), nil)
 		ctx.Set(types.HttpEndpointErrorKey, errMsg)
+		ctx.Set(types.HandlerStartTime, start)
 		return ctx.JSONBlob(http.StatusInternalServerError, errMsg)
 	}
 
@@ -277,6 +317,7 @@ func (r *registry) CompleteUpload(ctx echo.Context) error {
 	ctx.Response().Header().Set("Content-Length", "0")
 	ctx.Response().Header().Set("Docker-Content-Digest", ourHash)
 	ctx.Response().Header().Set("Location", locationHeader)
+	ctx.Set(types.HandlerStartTime, start)
 	return ctx.NoContent(http.StatusCreated)
 }
 
@@ -290,6 +331,11 @@ func (r *registry) LayerExists(ctx echo.Context) error {
 
 // HEAD /v2/<name>/manifests/<reference>
 func (r *registry) ManifestExists(ctx echo.Context) error {
+	start := time.Now()
+	defer func() {
+		r.logger.Log(ctx).Send()
+	}()
+
 	namespace := ctx.Param("username") + "/" + ctx.Param("imagename")
 	ref := ctx.Param("reference") // ref can be either tag or digest
 
@@ -302,6 +348,7 @@ func (r *registry) ManifestExists(ctx echo.Context) error {
 
 		errMsg := r.errorResponse(RegistryErrorCodeManifestBlobUnknown, err.Error(), details)
 		ctx.Set(types.HttpEndpointErrorKey, errMsg)
+		ctx.Set(types.HandlerStartTime, start)
 		return ctx.JSONBlob(http.StatusNotFound, errMsg)
 	}
 
@@ -311,9 +358,10 @@ func (r *registry) ManifestExists(ctx echo.Context) error {
 			"error":   "metadata not found for skylink",
 			"skylink": skylink,
 		}
-		r.debugf(lm)
+		r.logger.Error(lm)
 		errMsg := r.errorResponse(RegistryErrorCodeManifestBlobUnknown, "Manifest does not exist", nil)
 		ctx.Set(types.HttpEndpointErrorKey, errMsg)
+		ctx.Set(types.HandlerStartTime, start)
 		return ctx.JSONBlob(http.StatusNotFound, errMsg)
 	}
 
@@ -321,6 +369,7 @@ func (r *registry) ManifestExists(ctx echo.Context) error {
 	if err != nil {
 		errMsg := r.errorResponse(RegistryErrorCodeManifestInvalid, err.Error(), nil)
 		ctx.Set(types.HttpEndpointErrorKey, errMsg)
+		ctx.Set(types.HandlerStartTime, start)
 		return ctx.JSONBlob(http.StatusNotFound, errMsg)
 	}
 
@@ -330,8 +379,9 @@ func (r *registry) ManifestExists(ctx echo.Context) error {
 		lm := logMsg{
 			"errorUnmarshal": fmt.Sprintf("%s\n", errMsg),
 		}
-		r.debugf(lm)
+		r.logger.Error(lm)
 		ctx.Set(types.HttpEndpointErrorKey, errMsg)
+		ctx.Set(types.HandlerStartTime, start)
 		return ctx.JSONBlob(http.StatusNotFound, errMsg)
 	}
 
@@ -339,6 +389,7 @@ func (r *registry) ManifestExists(ctx echo.Context) error {
 	if err != nil {
 		errMsg := r.errorResponse(RegistryErrorCodeManifestUnknown, err.Error(), nil)
 		ctx.Set(types.HttpEndpointErrorKey, errMsg)
+		ctx.Set(types.HandlerStartTime, start)
 		return ctx.JSONBlob(http.StatusNotFound, errMsg)
 	}
 
@@ -347,15 +398,17 @@ func (r *registry) ManifestExists(ctx echo.Context) error {
 			"foundDigest":  manifest.Digest,
 			"clientDigest": ref,
 		}
-		r.debugf(details)
+		r.logger.Error(details)
 		errMsg := r.errorResponse(RegistryErrorCodeManifestInvalid, "manifest digest does not match", nil)
 		ctx.Set(types.HttpEndpointErrorKey, errMsg)
+		ctx.Set(types.HandlerStartTime, start)
 		return ctx.JSONBlob(http.StatusBadRequest, errMsg)
 	}
 
 	ctx.Response().Header().Set("Content-Type", "application/json")
 	ctx.Response().Header().Set("Content-Length", fmt.Sprintf("%d", size))
 	ctx.Response().Header().Set("Docker-Content-Digest", manifest.Digest)
+	ctx.Set(types.HandlerStartTime, start)
 	return ctx.NoContent(http.StatusOK)
 }
 
@@ -370,6 +423,11 @@ func (r *registry) CancelUpload(ctx echo.Context) error {
 
 // PullManifest GET /v2/<name>/manifests/<reference>
 func (r *registry) PullManifest(ctx echo.Context) error {
+	ctx.Set(types.HandlerStartTime, time.Now())
+	defer func() {
+		r.logger.Log(ctx).Send()
+	}()
+
 	namespace := ctx.Param("username") + "/" + ctx.Param("imagename")
 	ref := ctx.Param("reference")
 
@@ -377,7 +435,8 @@ func (r *registry) PullManifest(ctx echo.Context) error {
 	if err != nil {
 		errMsg := r.errorResponse(RegistryErrorCodeManifestUnknown, err.Error(), nil)
 		ctx.Set(types.HttpEndpointErrorKey, errMsg)
-		return ctx.JSONBlob(http.StatusNotFound, errMsg)
+		err = ctx.JSONBlob(http.StatusNotFound, errMsg)
+		return err
 	}
 
 	var md types.Metadata
@@ -424,6 +483,11 @@ func (r *registry) PullManifest(ctx echo.Context) error {
 }
 
 func (r *registry) PushManifest(ctx echo.Context) error {
+	start := time.Now()
+	defer func() {
+		r.logger.Log(ctx).Send()
+	}()
+
 	namespace := ctx.Param("username") + "/" + ctx.Param("imagename")
 	ref := ctx.Param("reference")
 	contentType := ctx.Request().Header.Get("Content-Type")
@@ -432,6 +496,7 @@ func (r *registry) PushManifest(ctx echo.Context) error {
 	if err != nil {
 		errMsg := r.errorResponse(RegistryErrorCodeManifestInvalid, err.Error(), nil)
 		ctx.Set(types.HttpEndpointErrorKey, errMsg)
+		ctx.Set(types.HandlerStartTime, start)
 		return ctx.JSONBlob(http.StatusBadRequest, errMsg)
 	}
 	ctx.Request().Body.Close()
@@ -442,6 +507,7 @@ func (r *registry) PushManifest(ctx echo.Context) error {
 	if err = json.Unmarshal(bz, &manifest); err != nil {
 		errMsg := r.errorResponse(RegistryErrorCodeBlobUnknown, err.Error(), nil)
 		ctx.Set(types.HttpEndpointErrorKey, errMsg)
+		ctx.Set(types.HandlerStartTime, start)
 		return ctx.JSONBlob(http.StatusBadRequest, errMsg)
 	}
 
@@ -450,6 +516,7 @@ func (r *registry) PushManifest(ctx echo.Context) error {
 	if err != nil {
 		errMsg := r.errorResponse(RegistryErrorCodeManifestBlobUnknown, err.Error(), nil)
 		ctx.Set(types.HttpEndpointErrorKey, errMsg)
+		ctx.Set(types.HandlerStartTime, start)
 		return ctx.JSONBlob(http.StatusNotFound, errMsg)
 	}
 
@@ -472,6 +539,7 @@ func (r *registry) PushManifest(ctx echo.Context) error {
 	if err = r.localCache.Update([]byte(namespace), metadata.Bytes()); err != nil {
 		errMsg := r.errorResponse(RegistryErrorCodeManifestInvalid, err.Error(), nil)
 		ctx.Set(types.HttpEndpointErrorKey, errMsg)
+		ctx.Set(types.HandlerStartTime, start)
 		return ctx.JSONBlob(http.StatusBadRequest, errMsg)
 	}
 
@@ -479,12 +547,18 @@ func (r *registry) PushManifest(ctx echo.Context) error {
 	ctx.Response().Header().Set("Location", locationHeader)
 	ctx.Response().Header().Set("Docker-Content-Digest", dig)
 	ctx.Response().Header().Set("X-Docker-Content-ID", skylink)
+	ctx.Set(types.HandlerStartTime, start)
 	return ctx.String(http.StatusCreated, "Created")
 }
 
 // Content discovery GET /v2/<name>/tags/list
 
 func (r *registry) ListTags(ctx echo.Context) error {
+	start := time.Now()
+	defer func() {
+		r.logger.Log(ctx).Send()
+	}()
+
 	namespace := ctx.Param("username") + "/" + ctx.Param("imagename")
 	limit := ctx.QueryParam("n")
 
@@ -492,6 +566,7 @@ func (r *registry) ListTags(ctx echo.Context) error {
 	if err != nil {
 		errMsg := r.errorResponse(RegistryErrorCodeTagInvalid, err.Error(), nil)
 		ctx.Set(types.HttpEndpointErrorKey, errMsg)
+		ctx.Set(types.HandlerStartTime, start)
 		return ctx.JSONBlob(http.StatusNotFound, errMsg)
 	}
 	var md types.Metadata
@@ -499,6 +574,7 @@ func (r *registry) ListTags(ctx echo.Context) error {
 	if err != nil {
 		errMsg := r.errorResponse(RegistryErrorCodeTagInvalid, err.Error(), nil)
 		ctx.Set(types.HttpEndpointErrorKey, errMsg)
+		ctx.Set(types.HandlerStartTime, start)
 		return ctx.JSONBlob(http.StatusNotFound, errMsg)
 	}
 	var tags []string
@@ -510,6 +586,7 @@ func (r *registry) ListTags(ctx echo.Context) error {
 		if err != nil {
 			errMsg := r.errorResponse(RegistryErrorCodeTagInvalid, err.Error(), nil)
 			ctx.Set(types.HttpEndpointErrorKey, errMsg)
+			ctx.Set(types.HandlerStartTime, start)
 			return ctx.JSONBlob(http.StatusNotFound, errMsg)
 		}
 		if n > 0 {
@@ -519,7 +596,7 @@ func (r *registry) ListTags(ctx echo.Context) error {
 			tags = []string{}
 		}
 	}
-
+	ctx.Set(types.HandlerStartTime, start)
 	sort.Strings(tags)
 	return ctx.JSON(http.StatusOK, echo.Map{
 		"name": namespace,
@@ -533,6 +610,11 @@ func (r *registry) List(ctx echo.Context) error {
 // GET /v2/<name>/blobs/<digest>
 
 func (r *registry) PullLayer(ctx echo.Context) error {
+	start := time.Now()
+	defer func() {
+		r.logger.Log(ctx).Send()
+	}()
+
 	namespace := ctx.Param("username") + "/" + ctx.Param("imagename")
 	clientDigest := ctx.Param("digest")
 
@@ -542,6 +624,7 @@ func (r *registry) PullLayer(ctx echo.Context) error {
 		if err != nil {
 			errMsg := r.errorResponse(RegistryErrorCodeBlobUnknown, err.Error(), nil)
 			ctx.Set(types.HttpEndpointErrorKey, errMsg)
+			ctx.Set(types.HandlerStartTime, start)
 			return ctx.JSONBlob(http.StatusNotFound, errMsg)
 		}
 		layerRef = &types.LayerRef{
@@ -565,6 +648,7 @@ func (r *registry) PullLayer(ctx echo.Context) error {
 	e := fmt.Errorf("skylink is empty").Error()
 	errMsg := r.errorResponse(RegistryErrorCodeBlobUnknown, e, detail)
 	ctx.Set(types.HttpEndpointErrorKey, errMsg)
+	ctx.Set(types.HandlerStartTime, start)
 	return ctx.JSONBlob(http.StatusNotFound, errMsg)
 }
 
@@ -579,6 +663,11 @@ func (r *registry) PushImage(ctx echo.Context) error {
 }
 
 func (r *registry) StartUpload(ctx echo.Context) error {
+	start := time.Now()
+	defer func() {
+		r.logger.Log(ctx).Send()
+	}()
+
 	namespace := ctx.Param("username") + "/" + ctx.Param("imagename")
 	clientDigest := ctx.QueryParam("digest")
 
@@ -596,6 +685,7 @@ func (r *registry) StartUpload(ctx echo.Context) error {
 			)
 
 			ctx.Set(types.HttpEndpointErrorKey, errMsg)
+			ctx.Set(types.HandlerStartTime, start)
 			return ctx.JSONBlob(http.StatusNotFound, errMsg)
 
 		}
@@ -613,6 +703,7 @@ func (r *registry) StartUpload(ctx echo.Context) error {
 				details,
 			)
 			ctx.Set(types.HttpEndpointErrorKey, errMsg)
+			ctx.Set(types.HandlerStartTime, start)
 			return ctx.JSONBlob(http.StatusBadRequest, errMsg)
 		}
 
@@ -623,8 +714,9 @@ func (r *registry) StartUpload(ctx echo.Context) error {
 				"error":  err.Error(),
 				"digest": dig,
 			}
-			r.debugf(lm)
+			r.logger.Error(lm)
 			ctx.Set(types.HttpEndpointErrorKey, errMsg)
+			ctx.Set(types.HandlerStartTime, start)
 			return ctx.JSONBlob(http.StatusRequestedRangeNotSatisfiable, errMsg)
 		}
 
@@ -644,9 +736,11 @@ func (r *registry) StartUpload(ctx echo.Context) error {
 		if err = r.localCache.Update([]byte(namespace), val.Bytes()); err != nil {
 			errMsg := r.errorResponse(RegistryErrorCodeUnsupported, err.Error(), nil)
 			ctx.Set(types.HttpEndpointErrorKey, errMsg)
+			ctx.Set(types.HandlerStartTime, start)
 			return ctx.JSONBlob(http.StatusInternalServerError, errMsg)
 		}
 		ctx.Response().Header().Set("Location", link)
+		ctx.Set(types.HandlerStartTime, start)
 		return ctx.NoContent(http.StatusCreated)
 	}
 
@@ -657,10 +751,16 @@ func (r *registry) StartUpload(ctx echo.Context) error {
 	ctx.Response().Header().Set("Content-Length", "0")
 	ctx.Response().Header().Set("Docker-Upload-UUID", id.String())
 	ctx.Response().Header().Set("Range", fmt.Sprintf("0-%d", 0))
+	ctx.Set(types.HandlerStartTime, start)
 	return ctx.NoContent(http.StatusAccepted)
 }
 
 func (r *registry) UploadProgress(ctx echo.Context) error {
+	start := time.Now()
+	defer func() {
+		r.logger.Log(ctx).Send()
+	}()
+
 	namespace := ctx.Param("username") + "/" + ctx.Param("imagename")
 	uuid := ctx.Param("uuid")
 
@@ -670,6 +770,7 @@ func (r *registry) UploadProgress(ctx echo.Context) error {
 		ctx.Response().Header().Set("Location", locationHeader)
 		ctx.Response().Header().Set("Range", "bytes=0-0")
 		ctx.Response().Header().Set("Docker-Upload-UUID", uuid)
+		ctx.Set(types.HandlerStartTime, start)
 		return ctx.NoContent(http.StatusNoContent)
 	}
 
@@ -679,6 +780,7 @@ func (r *registry) UploadProgress(ctx echo.Context) error {
 		ctx.Response().Header().Set("Location", locationHeader)
 		ctx.Response().Header().Set("Range", "bytes=0-0")
 		ctx.Response().Header().Set("Docker-Upload-UUID", uuid)
+		ctx.Set(types.HandlerStartTime, start)
 		return ctx.NoContent(http.StatusNoContent)
 	}
 
@@ -686,11 +788,16 @@ func (r *registry) UploadProgress(ctx echo.Context) error {
 	ctx.Response().Header().Set("Location", locationHeader)
 	ctx.Response().Header().Set("Range", fmt.Sprintf("bytes=0-%d", size))
 	ctx.Response().Header().Set("Docker-Upload-UUID", uuid)
+	ctx.Set(types.HandlerStartTime, start)
 	return ctx.NoContent(http.StatusNoContent)
 }
 
 // POST /v2/<name>/blobs/uploads/
 func (r *registry) PushLayer(ctx echo.Context) error {
+	start := time.Now()
+	defer func() {
+		r.logger.Log(ctx).Send()
+	}()
 
 	elem := strings.Split(ctx.Request().URL.Path, "/")
 	elem = elem[1:]
@@ -701,6 +808,7 @@ func (r *registry) PushLayer(ctx echo.Context) error {
 	if len(elem) < 4 {
 		errMsg := r.errorResponse(RegistryErrorCodeNameInvalid, "blobs must be attached to a repo", nil)
 		ctx.Set(types.HttpEndpointErrorKey, errMsg)
+		ctx.Set(types.HandlerStartTime, start)
 		return ctx.JSONBlob(http.StatusNotFound, errMsg)
 	}
 
@@ -710,12 +818,19 @@ func (r *registry) PushLayer(ctx echo.Context) error {
 	ctx.Response().Header().Set("Location", locationHeader)
 	ctx.Response().Header().Set("Docker-Upload-UUID", id.String())
 	ctx.Response().Header().Set("Range", "bytes=0-0")
+	ctx.Set(types.HandlerStartTime, start)
 	return ctx.NoContent(http.StatusAccepted)
 }
 
 // Should also look into 401 Code
 // https://docs.docker.com/registry/spec/api/
 func (r *registry) ApiVersion(ctx echo.Context) error {
+	start := time.Now()
+	defer func() {
+		r.logger.Log(ctx).Send()
+	}()
+
 	ctx.Response().Header().Set(HeaderDockerDistributionApiVersion, "registry/2.0")
+	ctx.Set(types.HandlerStartTime, start)
 	return ctx.String(http.StatusOK, "OK\n")
 }

--- a/registry/v2/types.go
+++ b/registry/v2/types.go
@@ -1,13 +1,13 @@
 package registry
 
 import (
+	"github.com/containerish/OpenRegistry/telemetry"
 	"sync"
 
 	"github.com/containerish/OpenRegistry/cache"
 	"github.com/containerish/OpenRegistry/skynet"
 	fluentbit "github.com/containerish/OpenRegistry/telemetry/fluent-bit"
 	"github.com/labstack/echo/v4"
-	"github.com/rs/zerolog"
 )
 
 /*
@@ -85,14 +85,12 @@ const (
 
 type (
 	registry struct {
-		log        zerolog.Logger
+		logger     telemetry.Logger
 		debug      bool
 		skynet     *skynet.Client
 		b          blobs
 		localCache cache.Store
-		echoLogger echo.Logger
 		mu         *sync.RWMutex
-		fluentbit  fluentbit.FluentBit
 	}
 
 	blobs struct {

--- a/router/router.go
+++ b/router/router.go
@@ -17,13 +17,6 @@ import (
 // nolint
 func Register(cfg *config.RegistryConfig, e *echo.Echo, reg registry.Registry, authSvc auth.Authentication, localCache cache.Store) {
 
-	//fbClient, err := fluentbit.New(cfg)
-	//if err != nil {
-	//	log.Fatalf("error in fluentbit init: %s\n", err.Error())
-	//}
-
-	// e.Use(telemetry.EchoLogger())
-	//e.Use(telemetry.ZerologMiddleware(telemetry.SetupLogger(), fbClient))
 	e.Use(middleware.Recover())
 	e.Use(middleware.CORS())
 

--- a/router/router.go
+++ b/router/router.go
@@ -1,15 +1,12 @@
 package router
 
 import (
-	"log"
 	"net/http"
 
 	"github.com/containerish/OpenRegistry/auth"
 	"github.com/containerish/OpenRegistry/cache"
 	"github.com/containerish/OpenRegistry/config"
 	"github.com/containerish/OpenRegistry/registry/v2"
-	"github.com/containerish/OpenRegistry/telemetry"
-	fluentbit "github.com/containerish/OpenRegistry/telemetry/fluent-bit"
 	"github.com/google/uuid"
 	"github.com/labstack/echo-contrib/prometheus"
 	"github.com/labstack/echo/v4"
@@ -20,13 +17,13 @@ import (
 // nolint
 func Register(cfg *config.RegistryConfig, e *echo.Echo, reg registry.Registry, authSvc auth.Authentication, localCache cache.Store) {
 
-	fbClient, err := fluentbit.New(cfg)
-	if err != nil {
-		log.Fatalf("error in fluentbit init: %s\n", err.Error())
-	}
+	//fbClient, err := fluentbit.New(cfg)
+	//if err != nil {
+	//	log.Fatalf("error in fluentbit init: %s\n", err.Error())
+	//}
 
 	// e.Use(telemetry.EchoLogger())
-	e.Use(telemetry.ZerologMiddleware(telemetry.SetupLogger(), fbClient))
+	//e.Use(telemetry.ZerologMiddleware(telemetry.SetupLogger(), fbClient))
 	e.Use(middleware.Recover())
 	e.Use(middleware.CORS())
 

--- a/telemetry/log.go
+++ b/telemetry/log.go
@@ -3,6 +3,8 @@ package telemetry
 import (
 	"bytes"
 	"encoding/json"
+	"fmt"
+	"github.com/labstack/gommon/log"
 	"io"
 	"os"
 	"strconv"
@@ -17,13 +19,17 @@ import (
 	"github.com/valyala/fasttemplate"
 )
 
+type Logger interface {
+	echo.Logger
+	Log(ctx echo.Context) *zerolog.Event
+}
+
 func SetupLogger() zerolog.Logger {
 	zerolog.TimeFieldFormat = zerolog.TimeFormatUnix
 	zerolog.SetGlobalLevel(zerolog.DebugLevel)
 
 	l := zerolog.New(os.Stdout)
 	l = l.With().Caller().Logger()
-
 	return l
 }
 
@@ -143,9 +149,263 @@ func ZerologMiddleware(baseLogger zerolog.Logger, fluentbitClient fluentbit.Flue
 				return
 			}
 
-			baseLogger.WithLevel(level).RawJSON("msg", buf.Bytes()).Send()
-			fluentbitClient.Send(bytes.TrimSpace(buf.Bytes()))
+			bz := bytes.TrimSpace(buf.Bytes())
+			baseLogger.WithLevel(level).RawJSON("msg", bz).Send()
+			fluentbitClient.Send(bz)
 			return
 		}
 	}
+}
+
+type logger struct {
+	zlog     zerolog.Logger
+	fbit     fluentbit.FluentBit
+	output   io.Writer
+	pool     *sync.Pool
+	template *fasttemplate.Template
+}
+
+func ZLogger(baseLogger zerolog.Logger, fluentbitClient fluentbit.FluentBit) Logger {
+	pool := &sync.Pool{
+		New: func() interface{} {
+			return bytes.NewBuffer(make([]byte, 256))
+		},
+	}
+	logFmt := `{"time":"${time_rfc3339}","x_request_id":"${request_id}","remote_ip":"${remote_ip}",` +
+		`"host":"${host}","method":"${method}","uri":"${uri}","user_agent":"${user_agent}",` +
+		`"status":${status},"error":"${error}","latency":${latency},"latency_human":"${latency_human}"` +
+		`,"bytes_in":${bytes_in},"bytes_out":${bytes_out}}` + "\n"
+
+	return &logger{
+		zlog:     baseLogger,
+		fbit:     fluentbitClient,
+		output:   os.Stdout,
+		pool:     pool,
+		template: fasttemplate.New(logFmt, "${", "}"),
+	}
+}
+
+func (l logger) Log(ctx echo.Context) *zerolog.Event {
+
+	start, ok := ctx.Get("start").(time.Time)
+	if !ok {
+		start = time.Now()
+	}
+
+	stop := time.Now()
+
+	buf := l.pool.Get().(*bytes.Buffer)
+	buf.Reset()
+	defer l.pool.Put(buf)
+
+	req := ctx.Request()
+	res := ctx.Response()
+
+	var level zerolog.Level
+	if _, err := l.template.ExecuteFunc(buf, func(_ io.Writer, tag string) (int, error) {
+		switch tag {
+		case "time_rfc3339":
+			return buf.WriteString(time.Now().Format(time.RFC3339))
+		case "request_id":
+			id := req.Header.Get(echo.HeaderXRequestID)
+			if id == "" {
+				id = res.Header().Get(echo.HeaderXRequestID)
+			}
+			return buf.WriteString(id)
+		case "remote_ip":
+			return buf.WriteString(ctx.RealIP())
+		case "host":
+			return buf.WriteString(req.Host)
+		case "uri":
+			return buf.WriteString(req.RequestURI)
+		case "method":
+			return buf.WriteString(req.Method)
+		case "path":
+			p := req.URL.Path
+			if p == "" {
+				p = "/"
+			}
+			return buf.WriteString(p)
+		case "protocol":
+			return buf.WriteString(req.Proto)
+		case "referer":
+			return buf.WriteString(req.Referer())
+		case "user_agent":
+			return buf.WriteString(req.UserAgent())
+		case "status":
+			status := res.Status
+			level = zerolog.InfoLevel
+			switch {
+			case status >= 500:
+				level = zerolog.ErrorLevel
+			case status >= 400:
+				level = zerolog.WarnLevel
+			case status >= 300:
+				level = zerolog.ErrorLevel
+			}
+			fmt.Println(res.Status)
+
+			return buf.WriteString(strconv.FormatInt(int64(status), 10))
+		case "error":
+			//if err != nil {
+			//	// Error may contain invalid JSON e.g. `"`
+			//	b, _ := json.Marshal(err.Error())
+			//	b = b[1 : len(b)-1]
+			//	return buf.Write(b)
+			//}
+
+			if ctxErr, ok := ctx.Get(types.HttpEndpointErrorKey).([]byte); ok {
+				return buf.Write(ctxErr)
+			}
+		case "latency":
+			l := stop.Sub(start)
+			return buf.WriteString(strconv.FormatInt(int64(l), 10))
+		case "latency_human":
+			return buf.WriteString(stop.Sub(start).String())
+		case "bytes_in":
+			cl := req.Header.Get(echo.HeaderContentLength)
+			if cl == "" {
+				cl = "0"
+			}
+			return buf.WriteString(cl)
+		case "bytes_out":
+			return buf.WriteString(strconv.FormatInt(res.Size, 10))
+		default:
+			switch {
+			case strings.HasPrefix(tag, "header:"):
+				return buf.Write([]byte(ctx.Request().Header.Get(tag[7:])))
+			case strings.HasPrefix(tag, "query:"):
+				return buf.Write([]byte(ctx.QueryParam(tag[6:])))
+			case strings.HasPrefix(tag, "form:"):
+				return buf.Write([]byte(ctx.FormValue(tag[5:])))
+			case strings.HasPrefix(tag, "cookie:"):
+				if cookie, cookieErr := ctx.Cookie(tag[7:]); cookieErr == nil {
+					return buf.Write([]byte(cookie.Value))
+				}
+			}
+		}
+		return 0, nil
+	}); err != nil {
+		buf.WriteString(fmt.Errorf("templateError: %w", err).Error())
+	}
+
+	bz := bytes.TrimSpace(buf.Bytes())
+	l.fbit.Send(bz)
+	return l.zlog.WithLevel(level).RawJSON("msg", bz)
+}
+
+func (l logger) Output() io.Writer {
+	return l.output
+}
+
+func (l logger) SetOutput(w io.Writer) {
+	l.zlog.Output(w)
+}
+
+// Prefix is not being used since zerologger is the only logger being used
+func (l logger) Prefix() string {
+	return ""
+}
+
+// SetPrefix is not being used since zerologger is the only logger being used
+func (l logger) SetPrefix(p string) {
+	return
+}
+
+func (l logger) Level() log.Lvl {
+	level := l.zlog.GetLevel()
+	return log.Lvl(level + 1)
+}
+
+// SetLevel - echo.loglvl starts from 1 while zerologger starts from 0
+func (l logger) SetLevel(v log.Lvl) {
+	l.zlog.Level(zerolog.Level(v - 1))
+}
+
+func (l logger) SetHeader(h string) {
+	return
+}
+
+func (l logger) Print(i ...interface{}) {
+	l.zlog.WithLevel(l.zlog.GetLevel()).Msgf("%v", i)
+}
+
+func (l logger) Printf(format string, args ...interface{}) {
+	l.zlog.WithLevel(l.zlog.GetLevel()).Msgf(format, args)
+}
+
+func (l logger) Printj(j log.JSON) {
+	l.zlog.WithLevel(l.zlog.GetLevel()).Fields(j).Send()
+}
+
+func (l logger) Debug(i ...interface{}) {
+	l.zlog.Debug().Msgf("%v", i)
+}
+
+func (l logger) Debugf(format string, args ...interface{}) {
+	l.zlog.Debug().Msgf(format, args)
+}
+
+func (l logger) Debugj(j log.JSON) {
+	l.zlog.Debug().Fields(j).Send()
+}
+
+func (l logger) Info(i ...interface{}) {
+	l.zlog.Info().Msgf("%v", i)
+}
+
+func (l logger) Infof(format string, args ...interface{}) {
+	l.zlog.Info().Msgf(format, args)
+}
+
+func (l logger) Infoj(j log.JSON) {
+	l.zlog.Info().Fields(j).Send()
+}
+
+func (l logger) Warn(i ...interface{}) {
+	l.zlog.Warn().Msgf("%v", i)
+}
+
+func (l logger) Warnf(format string, args ...interface{}) {
+	l.zlog.Warn().Msgf(format, args)
+}
+
+func (l logger) Warnj(j log.JSON) {
+	l.zlog.Warn().Fields(j).Send()
+}
+
+func (l logger) Error(i ...interface{}) {
+	l.zlog.Error().Msgf("%v", i)
+}
+
+func (l logger) Errorf(format string, args ...interface{}) {
+	l.zlog.Error().Msgf(format, args)
+}
+
+func (l logger) Errorj(j log.JSON) {
+	l.zlog.Error().Fields(j).Send()
+}
+
+func (l logger) Fatal(i ...interface{}) {
+	l.zlog.Fatal().Msgf("%v", i)
+}
+
+func (l logger) Fatalj(j log.JSON) {
+	l.zlog.Fatal().Fields(j).Send()
+}
+
+func (l logger) Fatalf(format string, args ...interface{}) {
+	l.zlog.Fatal().Msgf(format, args)
+}
+
+func (l logger) Panic(i ...interface{}) {
+	l.zlog.Panic().Msgf("%v", i)
+}
+
+func (l logger) Panicj(j log.JSON) {
+	l.zlog.Panic().Fields(j).Send()
+}
+
+func (l logger) Panicf(format string, args ...interface{}) {
+	l.zlog.Panic().Msgf(format, args)
 }

--- a/types/app_error_keys.go
+++ b/types/app_error_keys.go
@@ -2,4 +2,5 @@ package types
 
 const (
 	HttpEndpointErrorKey = "HTTP_ERROR"
+	HandlerStartTime     = "HANDLER_START_TIME"
 )


### PR DESCRIPTION
- Added new logger struct to contain zerologger and echo logger
- In the earlier implementation, the logger was being called in middleware which caused the log messages to return caller as middelware instead of the handler within which made debugging difficult 
- This PR fixes the issue by removing the middleware and calling logger inside each handler

Signed-off-by: guacamole <gunjanwalecha@gmail.com>