### PR TITLE
Chore: Dependency Cleanup

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,6 @@ go 1.17
 require (
 	github.com/SkynetLabs/go-skynet/v2 v2.0.2
 	github.com/dgraph-io/badger/v3 v3.2103.1
-	github.com/docker/distribution v2.8.0+incompatible
 	github.com/fatih/color v1.12.0
 	github.com/go-playground/validator/v10 v10.9.0
 	github.com/golang-jwt/jwt v3.2.2+incompatible
@@ -31,9 +30,6 @@ require (
 	github.com/jackc/pgtype v1.8.1 // indirect
 	github.com/jackc/puddle v1.1.3 // indirect
 	github.com/leodido/go-urn v1.2.1 // indirect
-)
-
-require (
 	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/cespare/xxhash v1.1.0 // indirect
 	github.com/cespare/xxhash/v2 v2.1.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -118,8 +118,6 @@ github.com/dgraph-io/ristretto v0.1.0/go.mod h1:fux0lOrBhrVCJd3lcTHsIJhq1T2rokOu
 github.com/dgrijalva/jwt-go v3.2.0+incompatible/go.mod h1:E3ru+11k8xSBh+hMPgOLZmtrrCbhqsmaPHjLKYnJCaQ=
 github.com/dgryski/go-farm v0.0.0-20190423205320-6a90982ecee2 h1:tdlZCpZ/P9DhczCTSixgIKmwPv6+wP5DGjqLYw5SUiA=
 github.com/dgryski/go-farm v0.0.0-20190423205320-6a90982ecee2/go.mod h1:SqUrOPUnsFjfmXRMNPybcSiG0BgUW2AuFH8PAnS2iTw=
-github.com/docker/distribution v2.8.0+incompatible h1:l9EaZDICImO1ngI+uTifW+ZYvvz7fKISBAKpg+MbWbY=
-github.com/docker/distribution v2.8.0+incompatible/go.mod h1:J2gT2udsDAN96Uj4KfcMRqY0/ypR+oyYUYmja8H+y+w=
 github.com/dustin/go-humanize v0.0.0-20171111073723-bb3d318650d4/go.mod h1:HtrtbFcZ19U5GC7JDqmcUSB87Iq5E25KnS6fMYU6eOk=
 github.com/dustin/go-humanize v1.0.0 h1:VSnTsYCnlFHaM2/igO1h6X3HA71jcobQuxemgkq4zYo=
 github.com/dustin/go-humanize v1.0.0/go.mod h1:HtrtbFcZ19U5GC7JDqmcUSB87Iq5E25KnS6fMYU6eOk=

--- a/registry/v2/registry.go
+++ b/registry/v2/registry.go
@@ -18,7 +18,7 @@ import (
 	"github.com/containerish/OpenRegistry/store/postgres"
 	"github.com/containerish/OpenRegistry/telemetry"
 	"github.com/containerish/OpenRegistry/types"
-	"github.com/docker/distribution/uuid"
+	"github.com/google/uuid"
 	"github.com/labstack/echo/v4"
 )
 
@@ -436,7 +436,7 @@ func (r *registry) StartUpload(ctx echo.Context) error {
 			MediaType:   ctx.Request().Header.Get("content-type"),
 			Digest:      dig,
 			SkynetLink:  skylink,
-			UUID:        uuid.Generate().String(),
+			UUID:        uuid.NewString(),
 			BlobDigests: nil,
 			Size:        len(bz),
 		}
@@ -465,7 +465,7 @@ func (r *registry) StartUpload(ctx echo.Context) error {
 		return ctx.NoContent(http.StatusCreated)
 	}
 
-	id := uuid.Generate()
+	id := uuid.New()
 	locationHeader := fmt.Sprintf("/v2/%s/blobs/uploads/%s", namespace, id.String())
 	txn, err := r.store.NewTxn(ctx.Request().Context())
 	if err != nil {
@@ -653,7 +653,7 @@ func (r *registry) PushManifest(ctx echo.Context) error {
 		layerIDs = append(layerIDs, layer.Digest)
 	}
 
-	id := uuid.Generate()
+	id := uuid.New()
 	mfc := types.ConfigV2{
 		UUID:      id.String(),
 		Namespace: namespace,
@@ -666,7 +666,7 @@ func (r *registry) PushManifest(ctx echo.Context) error {
 	}
 
 	val := &types.ImageManifestV2{
-		Uuid:          uuid.Generate().String(),
+		Uuid:          uuid.NewString(),
 		Namespace:     namespace,
 		MediaType:     "",
 		SchemaVersion: 2,
@@ -720,7 +720,7 @@ func (r *registry) PushLayer(ctx echo.Context) error {
 		return ctx.JSONBlob(http.StatusNotFound, errMsg)
 	}
 
-	id := uuid.Generate()
+	id := uuid.New()
 	p := path.Join(elem[1 : len(elem)-2]...)
 	locationHeader := fmt.Sprintf("/v2/%s/blobs/uploads/%s", p, id.String())
 	ctx.Response().Header().Set("Location", locationHeader)


### PR DESCRIPTION
Removed distribution package, since we were only using it for it's sub-package uuid, we're already using google's uuid package so it was redundant