### PR TITLE
Chore: Adds cancel-in-progress on consecutive push

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -1,6 +1,11 @@
 name: golangci-lint
 on:
   pull_request:
+
+concurrency:
+  group: linter-${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
 jobs:
   golangci:
     name: lint

--- a/.github/workflows/oci-dist-spec-content-discovery.yml
+++ b/.github/workflows/oci-dist-spec-content-discovery.yml
@@ -3,6 +3,10 @@ name: OCI Distribution Spec
 on:
   pull_request:
 
+concurrency:
+  group: content-discovery-${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
 jobs:
   content-discovery:
     runs-on: ubuntu-latest

--- a/.github/workflows/oci-dist-spec-content-management.yml
+++ b/.github/workflows/oci-dist-spec-content-management.yml
@@ -3,6 +3,10 @@ name: OCI Distribution Spec
 on:
   pull_request:
 
+concurrency:
+  group: content-management-${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
 jobs:
   content-management:
     runs-on: ubuntu-latest

--- a/.github/workflows/oci-dist-spec-pull.yml
+++ b/.github/workflows/oci-dist-spec-pull.yml
@@ -3,6 +3,10 @@ name: OCI Distribution Spec
 on:
   pull_request:
 
+concurrency:
+  group: pull-${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
 jobs:
   pull:
     runs-on: ubuntu-latest

--- a/.github/workflows/oci-dist-spec-push.yml
+++ b/.github/workflows/oci-dist-spec-push.yml
@@ -3,6 +3,10 @@ name: OCI Distribution Spec
 on:
   pull_request:
 
+concurrency:
+  group: push-${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
 jobs:
   push:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Adds Workflow groups and cancels any older action runs when we push consecutively.

This is how it works:
1. Make a change, push and raise a PR, as of now, we run 10 Github Actions.
2. See a typo, or a fix, commit and push before the previous action has passed
3. Now there are 2 simultaneous Github Actions running, out of which, only the newer one matters.
4. This PR cancels the older action that is (are) running and only keeps the latest iteration of it.