### PR TITLE
Fix: Skynet Portal URL from config file

### DIFF
--- a/config.yaml.example
+++ b/config.yaml.example
@@ -20,7 +20,7 @@ oauth:
     client_id:
     client_secret:
 skynet:
-  portal_url: https://siasky.net
+  portal_url: https://siasky.dev
   api_key: skynet-key
 database:
   kind: postgres

--- a/config/config.go
+++ b/config/config.go
@@ -32,7 +32,7 @@ type (
 	}
 
 	Skynet struct {
-		SkynetPortalURL string `mapstructure:"skynet_portal_url"`
+		SkynetPortalURL string `mapstructure:"portal_url"`
 		EndpointPath    string `mapstructure:"endpoint_path"`
 		ApiKey          string `mapstructure:"api_key"`
 		CustomUserAgent string `mapstructure:"custom_user_agent"`


### PR DESCRIPTION
config file declares the portal url as:
```yaml
skynet:
  portal_url: https://siasky.net
```

but the datatype was declared with tag `skynet_portal_url` which was causing the url defined in the config file to be reset to default always since skynet sdk defaults to `siasky.net` when skynet url is empty