### PR TITLE
fix: Bump Skynet SDK version

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -49,7 +49,6 @@ type (
 		EndpointPath    string `yaml:"endpoint_path" mapstructure:"endpoint_path"`
 		ApiKey          string `yaml:"api_key" mapstructure:"api_key"`
 		CustomUserAgent string `yaml:"custom_user_agent" mapstructure:"custom_user_agent"`
-		CustomCookie    string `yaml:"custom_cookie" mapstructure:"custom_cookie"`
 	}
 
 	Log struct {

--- a/go.mod
+++ b/go.mod
@@ -72,4 +72,4 @@ require (
 	gopkg.in/yaml.v3 v3.0.0 // indirect
 )
 
-replace github.com/SkynetLabs/go-skynet/v2 => github.com/containerish/go-skynet/v2 v2.0.2-0.20220411175612-3c3d850b3a0c
+replace github.com/SkynetLabs/go-skynet/v2 => github.com/containerish/go-skynet/v2 v2.0.2-0.20220628192246-f4c6cef0e2f1

--- a/go.sum
+++ b/go.sum
@@ -108,6 +108,8 @@ github.com/cockroachdb/apd v1.1.0 h1:3LFP3629v+1aKXU5Q37mxmRxX/pIu1nijXydLShEq5I
 github.com/cockroachdb/apd v1.1.0/go.mod h1:8Sl8LxpKi29FqWXR16WEFZRNSz3SoPzUzeMeY4+DwBQ=
 github.com/containerish/go-skynet/v2 v2.0.2-0.20220411175612-3c3d850b3a0c h1:lYT9eGuBaXNIZmJkbgA/HHxkNWu8cPAWT3jKpYTnbXQ=
 github.com/containerish/go-skynet/v2 v2.0.2-0.20220411175612-3c3d850b3a0c/go.mod h1:XOk0zwGlXeGjHQgmhXTEk7qTD6FVv3dXPW38Wh3XsIc=
+github.com/containerish/go-skynet/v2 v2.0.2-0.20220628192246-f4c6cef0e2f1 h1:DEHhTYDXlsLkpdOmdYwg4fO195hLO3UeInytr5MsvsE=
+github.com/containerish/go-skynet/v2 v2.0.2-0.20220628192246-f4c6cef0e2f1/go.mod h1:XOk0zwGlXeGjHQgmhXTEk7qTD6FVv3dXPW38Wh3XsIc=
 github.com/coreos/go-semver v0.3.0/go.mod h1:nnelYz7RCh+5ahJtPPxZlU+153eP4D4r3EedlOD2RNk=
 github.com/coreos/go-systemd v0.0.0-20190321100706-95778dfbb74e/go.mod h1:F5haX7vjVVG0kc13fIWeqUViNPyEJxv/OmvnBo0Yme4=
 github.com/coreos/go-systemd v0.0.0-20190719114852-fd7a80b32e1f/go.mod h1:F5haX7vjVVG0kc13fIWeqUViNPyEJxv/OmvnBo0Yme4=

--- a/skynet/skynet.go
+++ b/skynet/skynet.go
@@ -17,8 +17,7 @@ func NewClient(oc *config.OpenRegistryConfig) *Client {
 
 	opts := skynet.Options{
 		CustomUserAgent: oc.SkynetConfig.CustomUserAgent,
-		APIKey:          oc.SkynetConfig.ApiKey,
-		CustomCookie:    oc.SkynetConfig.ApiKey,
+		SkynetAPIKey:    oc.SkynetConfig.ApiKey,
 		HttpClient:      newHttpClientForSkynet(),
 	}
 


### PR DESCRIPTION
This PR bumps the Skynet SDK version from our fork. Skynet has switched
to API Keys instead of JWT Header. This broke our existing Skynet
Integration. Simply by passing the variable of `SkynetApiKey` while
initlizing the Skynet Client, entire functionality is restored.

Signed-off-by: jay-dee7 <jasdeepsingh.uppal@gmail.com>