### PR TITLE
fix: Bump Skynet SDK

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -72,4 +72,4 @@ require (
 	gopkg.in/yaml.v3 v3.0.0 // indirect
 )
 
-replace github.com/SkynetLabs/go-skynet/v2 => github.com/containerish/go-skynet/v2 v2.0.2-0.20220628192246-f4c6cef0e2f1
+replace github.com/SkynetLabs/go-skynet/v2 => github.com/containerish/go-skynet/v2 v2.0.2-0.20220629062209-f31ff192458d

--- a/go.sum
+++ b/go.sum
@@ -110,6 +110,8 @@ github.com/containerish/go-skynet/v2 v2.0.2-0.20220411175612-3c3d850b3a0c h1:lYT
 github.com/containerish/go-skynet/v2 v2.0.2-0.20220411175612-3c3d850b3a0c/go.mod h1:XOk0zwGlXeGjHQgmhXTEk7qTD6FVv3dXPW38Wh3XsIc=
 github.com/containerish/go-skynet/v2 v2.0.2-0.20220628192246-f4c6cef0e2f1 h1:DEHhTYDXlsLkpdOmdYwg4fO195hLO3UeInytr5MsvsE=
 github.com/containerish/go-skynet/v2 v2.0.2-0.20220628192246-f4c6cef0e2f1/go.mod h1:XOk0zwGlXeGjHQgmhXTEk7qTD6FVv3dXPW38Wh3XsIc=
+github.com/containerish/go-skynet/v2 v2.0.2-0.20220629062209-f31ff192458d h1:FJN3IBHTidtf0RgzkUpqESXY9Q7IomATzYgKlwMpYw0=
+github.com/containerish/go-skynet/v2 v2.0.2-0.20220629062209-f31ff192458d/go.mod h1:XOk0zwGlXeGjHQgmhXTEk7qTD6FVv3dXPW38Wh3XsIc=
 github.com/coreos/go-semver v0.3.0/go.mod h1:nnelYz7RCh+5ahJtPPxZlU+153eP4D4r3EedlOD2RNk=
 github.com/coreos/go-systemd v0.0.0-20190321100706-95778dfbb74e/go.mod h1:F5haX7vjVVG0kc13fIWeqUViNPyEJxv/OmvnBo0Yme4=
 github.com/coreos/go-systemd v0.0.0-20190719114852-fd7a80b32e1f/go.mod h1:F5haX7vjVVG0kc13fIWeqUViNPyEJxv/OmvnBo0Yme4=

--- a/skynet/skynet.go
+++ b/skynet/skynet.go
@@ -35,7 +35,7 @@ func NewClient(oc *config.OpenRegistryConfig) *Client {
 
 func (c *Client) Upload(namespace, digest string, content []byte, pin bool) (string, error) {
 	opts := skynet.DefaultUploadOptions
-	opts.APIKey = c.skynet.Options.APIKey
+	opts.SkynetAPIKey = c.skynet.Options.SkynetAPIKey
 	opts.CustomDirname = namespace
 
 	data := make(skynet.UploadData)


### PR DESCRIPTION
In this PR, we bumped the Skynet SDK to use
`v2.0.2-0.20220629062209-f31ff192458d` version. Skynet updated their Pin
Skylink API to return a response body and StatusOk (200) code, previously they
returned NoContent (204) Status Code

Signed-off-by: jay-dee7 <jasdeepsingh.uppal@gmail.com>