### PR TITLE
chore: Run Dependabot weekly on fridays

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,7 +4,8 @@ updates:
   - package-ecosystem: "gomod"
     directory: "/"
     schedule:
-      interval: "daily"
+      interval: "weekly"
+      day: "friday"
     commit-message:
       prefix: "go.mod:"
     open-pull-requests-limit: 25
@@ -19,6 +20,7 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+      day: "friday"
     commit-message:
       prefix: ".github:"
     assignees:


### PR DESCRIPTION
### Motivation & Context:

At this point, Dependabot has really become a pain. The frequency of PRs is too short.

### Description:

This PR sets Dependabot interval to a week.

### Types of Changes:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### PR Checklist:

- [x] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I've read the CONTRIBUTION guide
- [x] I have signed-off my commits with git commit -s
