### PR TITLE
fix(ci): Use unique names for OCI report output files

### DIFF
--- a/.github/workflows/oci-dist-spec-content-discovery.yml
+++ b/.github/workflows/oci-dist-spec-content-discovery.yml
@@ -79,9 +79,12 @@ jobs:
           OCI_HIDE_SKIPPED_WORKFLOWS: 1
           OCI_CROSSMOUNT_NAMESPACE: ${{secrets.OPENREGISTRY_USERNAME}}/distribution-cross-mount
           OCI_DEBUG: 0
+      - name: Set output report name
+        id: vars
+        run: echo "short_commit_hash=$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
       - name: Upload test results zip as build artifact
         uses: actions/upload-artifact@v3
         with:
-          name: oci-test-results-${{ github.sha }}
+          name: oci-distribution-content-discovery-report-${{ steps.vars.outputs.short_commit_hash }}
           path: .out/
         if: always()

--- a/.github/workflows/oci-dist-spec-content-management.yml
+++ b/.github/workflows/oci-dist-spec-content-management.yml
@@ -79,9 +79,12 @@ jobs:
           OCI_HIDE_SKIPPED_WORKFLOWS: 1
           OCI_CROSSMOUNT_NAMESPACE: ${{secrets.OPENREGISTRY_USERNAME}}/distribution-cross-mount
           OCI_DEBUG: 0
+      - name: Set output report name
+        id: vars
+        run: echo "short_commit_hash=$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
       - name: Upload test results zip as build artifact
         uses: actions/upload-artifact@v3
         with:
-          name: oci-test-results-${{ github.sha }}
+          name: oci-distribution-content-management-report-${{ steps.vars.outputs.short_commit_hash }}
           path: .out/
         if: always()

--- a/.github/workflows/oci-dist-spec-pull.yml
+++ b/.github/workflows/oci-dist-spec-pull.yml
@@ -79,9 +79,14 @@ jobs:
           OCI_HIDE_SKIPPED_WORKFLOWS: 1
           OCI_CROSSMOUNT_NAMESPACE: ${{secrets.OPENREGISTRY_USERNAME}}/distribution-cross-mount
           OCI_DEBUG: 0
+      - name: Set output report name
+        id: vars
+        run: echo "short_commit_hash=$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
       - name: Upload test results zip as build artifact
         uses: actions/upload-artifact@v3
-        with:
-          name: oci-test-results-${{ github.sha }}
-          path: .out/
         if: always()
+        with:
+          name: oci-distribution-pull-report-${{ steps.vars.outputs.short_commit_hash }}
+          path: .out/
+        env:
+          GITHUB_SHORT_SHA: $(echo ${ github.sha } | cut -c1-8)

--- a/.github/workflows/oci-dist-spec-push.yml
+++ b/.github/workflows/oci-dist-spec-push.yml
@@ -80,9 +80,12 @@ jobs:
           OCI_HIDE_SKIPPED_WORKFLOWS: 1
           OCI_CROSSMOUNT_NAMESPACE: ${{secrets.OPENREGISTRY_USERNAME}}/distribution-cross-mount
           OCI_DEBUG: 0
+      - name: Set output report name
+        id: vars
+        run: echo "short_commit_hash=$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
       - name: Upload test results zip as build artifact
         uses: actions/upload-artifact@v3
         with:
-          name: oci-test-results-${{ github.sha }}
+          name: oci-distribution-push-report-${{ steps.vars.outputs.short_commit_hash }}
           path: .out/
         if: always()


### PR DESCRIPTION
### Motivation & Context:
All of our Github Actions for OCI were uploading their OCI Conformance reports with the same name, which lead to the overwriting of reports uploaded. We only persisted the report of the action the uploaded the file last. This PR fixes that.

### Description:
We now use unique names for all the reports being uploaded. The filename format is: `oci-distribution-pull-report-${{ steps.vars.outputs.short_commit_hash }}`

The short commit hash is computed using the following command:

```bash
git rev-parse --short HEAD
```

### Types of Changes:

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### PR Checklist:

- [x] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [x] I've read the CONTRIBUTION guide
- [x] I have signed-off my commits with git commit -s
