### PR TITLE
add(ci): GitHub Actions debugging

### DIFF
--- a/.github/workflows/oci-dist-spec-content-discovery.yml
+++ b/.github/workflows/oci-dist-spec-content-discovery.yml
@@ -79,6 +79,9 @@ jobs:
           OCI_HIDE_SKIPPED_WORKFLOWS: 1
           OCI_CROSSMOUNT_NAMESPACE: ${{secrets.OPENREGISTRY_USERNAME}}/distribution-cross-mount
           OCI_DEBUG: 0
+      - name: Setup tmate session if mode is debug and OpenRegistry or OCI Tests Fail
+        uses: mxschmitt/action-tmate@v3
+        if:  ${{ github.event_name == 'workflow_dispatch' && inputs.debug_enabled }}
       - name: Set output report name
         id: vars
         run: echo "short_commit_hash=$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT

--- a/.github/workflows/oci-dist-spec-content-management.yml
+++ b/.github/workflows/oci-dist-spec-content-management.yml
@@ -79,6 +79,9 @@ jobs:
           OCI_HIDE_SKIPPED_WORKFLOWS: 1
           OCI_CROSSMOUNT_NAMESPACE: ${{secrets.OPENREGISTRY_USERNAME}}/distribution-cross-mount
           OCI_DEBUG: 0
+      - name: Setup tmate session if mode is debug and OpenRegistry or OCI Tests Fail
+        uses: mxschmitt/action-tmate@v3
+        if:  ${{ github.event_name == 'workflow_dispatch' && inputs.debug_enabled }}
       - name: Set output report name
         id: vars
         run: echo "short_commit_hash=$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT

--- a/.github/workflows/oci-dist-spec-pull.yml
+++ b/.github/workflows/oci-dist-spec-pull.yml
@@ -2,6 +2,12 @@ name: OCI Distribution Spec
 
 on:
   workflow_call:
+    inputs:
+      debug_enabled:
+        type: boolean
+        description: 'Run the build with tmate debugging enabled (https://github.com/marketplace/actions/debugging-with-tmate)'
+        required: false
+        default: false
 
 concurrency:
   group: pull-${{ github.workflow }}-${{ github.head_ref || github.run_id }}
@@ -79,6 +85,9 @@ jobs:
           OCI_HIDE_SKIPPED_WORKFLOWS: 1
           OCI_CROSSMOUNT_NAMESPACE: ${{secrets.OPENREGISTRY_USERNAME}}/distribution-cross-mount
           OCI_DEBUG: 0
+      - name: Setup tmate session if mode is debug and OpenRegistry or OCI Tests Fail
+        uses: mxschmitt/action-tmate@v3
+        if:  ${{ github.event_name == 'workflow_dispatch' && inputs.debug_enabled }}
       - name: Set output report name
         id: vars
         run: echo "short_commit_hash=$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT

--- a/.github/workflows/oci-dist-spec-push.yml
+++ b/.github/workflows/oci-dist-spec-push.yml
@@ -80,6 +80,9 @@ jobs:
           OCI_HIDE_SKIPPED_WORKFLOWS: 1
           OCI_CROSSMOUNT_NAMESPACE: ${{secrets.OPENREGISTRY_USERNAME}}/distribution-cross-mount
           OCI_DEBUG: 0
+      - name: Setup tmate session if mode is debug and OpenRegistry or OCI Tests Fail
+        uses: mxschmitt/action-tmate@v3
+        if:  ${{ github.event_name == 'workflow_dispatch' && inputs.debug_enabled }}
       - name: Set output report name
         id: vars
         run: echo "short_commit_hash=$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT


### PR DESCRIPTION
### Motivation & Context:

It's a pain to debug our CI when something goes wrong. Many times CI fails because of configuration errors or build errors. This PR adds a GitHub Action which can be triggered manually and it let's us SSH into the GitHub Action.


### Description:

Adds [mxschmitt/action-tmate@v3](https://github.com/mxschmitt/action-tmate). This GitHub action is a conditional step in our OCI GitHub Actions. To trigger this, we need to manually trigger a workflow that we're interested in debugging and by enabling the debug mode

### Types of Changes:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### PR Checklist:

- [x] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [x] I've read the CONTRIBUTION guide
- [x] I have signed-off my commits with git commit -s
