### PR TITLE
fix: Upload progress byte size

### DIFF
--- a/registry/v2/registry.go
+++ b/registry/v2/registry.go
@@ -511,7 +511,7 @@ func (r *registry) UploadProgress(ctx echo.Context) error {
 
 	locationHeader := fmt.Sprintf("/v2/%s/blobs/uploads/%s", namespace, uuid)
 	ctx.Response().Header().Set("Location", locationHeader)
-	ctx.Response().Header().Set("Range", fmt.Sprintf("bytes=0-%d", metadata.ContentLength))
+	ctx.Response().Header().Set("Range", fmt.Sprintf("bytes=0-%d", metadata.ContentLength-1))
 	ctx.Response().Header().Set("Docker-Upload-UUID", uuid)
 	echoErr := ctx.NoContent(http.StatusNoContent)
 	r.logger.Log(ctx, nil)


### PR DESCRIPTION
### Motivation & Context:
The OCI test for slate blob upload was failing for byte size being 1 more than what it should be. We were sending 0-lenght which increases it by one. Updated the bytes 0-{length-1)

### Description:
Updated byte size for update progress function, OCI test is now passing
`
ctx.Response().Header().Set("Range", fmt.Sprintf("bytes=0-%d", metadata.ContentLength-1))
`

### Types of Changes:

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### PR Checklist:

- [x] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [x] I've read the CONTRIBUTION guide
- [x] I have signed-off my commits with git commit -s
