### PR TITLE
fix: JWT parsing in middlewares

### DIFF
--- a/auth/jwt_middleware.go
+++ b/auth/jwt_middleware.go
@@ -77,7 +77,7 @@ func (a *auth) JWT() echo.MiddlewareFunc {
 		SigningKeys:    map[string]interface{}{},
 		SigningMethod:  jwt.SigningMethodRS256.Name,
 		Claims:         &Claims{},
-		TokenLookup:    fmt.Sprintf("cookie:%s,header:%s", AccessCookieKey, echo.HeaderAuthorization),
+		TokenLookup:    fmt.Sprintf("cookie:%s,header:%s:Bearer ", AccessCookieKey, echo.HeaderAuthorization),
 	})
 }
 
@@ -161,6 +161,6 @@ func (a *auth) JWTRest() echo.MiddlewareFunc {
 		SigningKey:     privkey,
 		SigningMethod:  jwt.SigningMethodRS256.Name,
 		Claims:         &Claims{},
-		TokenLookup:    fmt.Sprintf("cookie:%s,header:%s", AccessCookieKey, echo.HeaderAuthorization),
+		TokenLookup:    fmt.Sprintf("cookie:%s,header:%s:Bearer ", AccessCookieKey, echo.HeaderAuthorization),
 	})
 }


### PR DESCRIPTION
### Motivation & Context:

The JWT library that we use (https://github.com/golang-jwt/jwt) recently changed the method of token extraction.
Previously, you could pass the following to the `JWTConfig` and it would work fine:

```go
middleware.JWTConfig {
  ...
  TokenLookup: "cookie:access_token,header:Authorization"
  ...
}
```

and this would extract the JWT from the Cookie or the Header.
gq
But this is broken in the JWT lib since at least `v4.5.0`

The new method is to also chain the Auth Scheme with the identifier like so:

```go
middleware.JWTConfig {
  ...
  TokenLookup: "cookie:access_token,header:Authorization:Bearer "
  ...
}
```

> Notice the Bearer has a trailing space, which is required.


### Description:
This PR adds the Auth Scheme (which is `Bearer` in our case) to the `TokenLookup` field. So the header lookup identifier becomes:

> `header:Authorization:Bearer `

### Types of Changes:

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### PR Checklist:

- [x] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [x] I've read the CONTRIBUTION guide
- [x] I have signed-off my commits with git commit -s
