### PR TITLE
chore(ci): Lock OCI distribution conformance version

### DIFF
--- a/.github/workflows/oci-dist-spec-content-discovery.yml
+++ b/.github/workflows/oci-dist-spec-content-discovery.yml
@@ -76,6 +76,7 @@ jobs:
         run: |
           git clone https://github.com/opencontainers/distribution-spec.git
           pushd distribution-spec/conformance
+          git checkout 235fa1b
           go test -c
           ./conformance.test
           popd

--- a/.github/workflows/oci-dist-spec-content-management.yml
+++ b/.github/workflows/oci-dist-spec-content-management.yml
@@ -76,6 +76,7 @@ jobs:
         run: |
           git clone https://github.com/opencontainers/distribution-spec.git
           pushd distribution-spec/conformance
+          git checkout 235fa1b
           go test -c
           ./conformance.test
           popd

--- a/.github/workflows/oci-dist-spec-pull.yml
+++ b/.github/workflows/oci-dist-spec-pull.yml
@@ -76,6 +76,7 @@ jobs:
         run: |
           git clone https://github.com/opencontainers/distribution-spec.git
           pushd distribution-spec/conformance
+          git checkout 235fa1b
           go test -c
           ./conformance.test
           popd

--- a/.github/workflows/oci-dist-spec-push.yml
+++ b/.github/workflows/oci-dist-spec-push.yml
@@ -77,6 +77,7 @@ jobs:
         run: |
           git clone https://github.com/opencontainers/distribution-spec.git
           pushd distribution-spec/conformance
+          git checkout 235fa1b
           go test -c
           ./conformance.test
           popd
@@ -92,8 +93,7 @@ jobs:
           OCI_DEBUG: 0
       - name: Setup tmate session if mode is debug and OpenRegistry or OCI Tests Fail
         uses: mxschmitt/action-tmate@v3
-        if:  ${{ always() }}
-        # if:  ${{ always() && (github.event_name == 'workflow_dispatch') && inputs.debug_enabled }}
+        if:  ${{ always() && (github.event_name == 'workflow_dispatch') && inputs.debug_enabled }}
       - name: Set output report name
         id: vars
         run: echo "short_commit_hash=$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT


### PR DESCRIPTION
### Motivation & Context:

OCI Conformance is going through some decisions about how to handle blob mounting from other repositories. Until that's decided we're locking the version to a particular commit where everything is working.

### Description:

This PR locks the version of OCI Conformance tests to `235fa1b`

### Types of Changes:

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### PR Checklist:

- [x] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [x] I've read the CONTRIBUTION guide
- [x] I have signed-off my commits with git commit -s
