### PR TITLE
feat(ci): Mock storage

### DIFF
--- a/.github/workflows/oci-dist-spec-content-discovery.yml
+++ b/.github/workflows/oci-dist-spec-content-discovery.yml
@@ -52,26 +52,13 @@ jobs:
           cp config.example.yaml config.yaml
           yq e -i '.environment = "ci"' config.yaml
           IP=$IP yq e -i '.database.host = env(IP)' config.yaml
-          yq e -i '.dfs.filebase.enabled = "true"' config.yaml
-          FILEBASE_KEY=${{ secrets.FILEBASE_KEY }} yq e -i '.dfs.filebase.access_key = env(FILEBASE_KEY)' config.yaml
-          FILEBASE_SECRET=${{ secrets.FILEBASE_SECRET }} yq e -i '.dfs.filebase.secret_key = env(FILEBASE_SECRET)' config.yaml
-          FILEBASE_BUCKET=${{ secrets.FILEBASE_BUCKET }} yq e -i '.dfs.filebase.bucket_name = env(FILEBASE_BUCKET)' config.yaml
-          FILEBASE_ENDPOINT=${{ secrets.FILEBASE_ENDPOINT }} yq e -i '.dfs.filebase.endpoint = env(FILEBASE_ENDPOINT)' config.yaml
-          FILEBASE_RESOLVER_URL=${{ secrets.FILEBASE_RESOLVER_URL }} yq e -i '.dfs.filebase.dfs_link_resolver = env(FILEBASE_RESOLVER_URL)' config.yaml
-          # yq e -i '.dfs.storj.type = "uplink"' config.yaml
-          # STORJ_CI_ACCESS_KEY=${{ secrets.STORJ_CI_ACCESS_KEY }} yq e -i '.dfs.storj.access_key = env(STORJ_CI_ACCESS_KEY)' config.yaml
-          # STORJ_CI_SECRET_KEY=${{ secrets.STORJ_CI_SECRET_KEY }} yq e -i '.dfs.storj.secret_key = env(STORJ_CI_SECRET_KEY)' config.yaml
-          # STORJ_CI_BUCKET_NAME=${{ secrets.STORJ_CI_BUCKET_NAME }} yq e -i '.dfs.storj.bucket_name = env(STORJ_CI_BUCKET_NAME)' config.yaml
-          # STORJ_CI_ACCESS_GRANT_TOKEN=${{ secrets.STORJ_CI_ACCESS_GRANT_TOKEN }} yq e -i '.dfs.storj.access_grant_token = env(STORJ_CI_ACCESS_GRANT_TOKEN)' config.yaml
-          # STORJ_CI_ENDPOINT=${{ secrets.STORJ_CI_ENDPOINT }} yq e -i '.dfs.storj.endpoint = env(STORJ_CI_ENDPOINT)' config.yaml
-          # STORJ_CI_RESOLVER_ENDPOINT=${{ secrets.STORJ_CI_RESOLVER_ENDPOINT }} yq e -i '.dfs.storj.dfs_link_resolver = env(STORJ_CI_RESOLVER_ENDPOINT)' config.yaml
-          # STORJ_CI_LINK_SHARE_SERVICE_ENDPOINT=${{ secrets.STORJ_CI_LINK_SHARE_SERVICE_ENDPOINT }} yq e -i '.dfs.storj.link_share_service = env(STORJ_CI_LINK_SHARE_SERVICE_ENDPOINT)' config.yaml
+          yq e -i '.dfs.mock.enabled = "true"' config.yaml
           echo "IP=$IP" >> $GITHUB_ENV
           echo "OCI_ROOT_URL=http://$IP:5000" >> $GITHUB_ENV
           DISTRIBUTION_REF="local-distribution:v$(date +%Y%m%d%H%M%S)"
           docker build -f ./Dockerfile -t "${DISTRIBUTION_REF}" .
           make certs
-          docker run --rm -p 5000:5000 \
+          docker run --rm -p 5000:5000 -p 8080:8080 \
             --mount="type=bind,source=${PWD}/config.yaml,target=/home/runner/.openregistry/config.yaml" \
             -v "$PWD/.certs:/home/runner/.certs" \
             --env="CI_SYS_ADDR=$IP:5000" -d "${DISTRIBUTION_REF}"

--- a/.github/workflows/oci-dist-spec-content-management.yml
+++ b/.github/workflows/oci-dist-spec-content-management.yml
@@ -52,26 +52,13 @@ jobs:
           cp config.example.yaml config.yaml
           yq e -i '.environment = "ci"' config.yaml
           IP=$IP yq e -i '.database.host = env(IP)' config.yaml
-          yq e -i '.dfs.filebase.enabled = "true"' config.yaml
-          FILEBASE_KEY=${{ secrets.FILEBASE_KEY }} yq e -i '.dfs.filebase.access_key = env(FILEBASE_KEY)' config.yaml
-          FILEBASE_SECRET=${{ secrets.FILEBASE_SECRET }} yq e -i '.dfs.filebase.secret_key = env(FILEBASE_SECRET)' config.yaml
-          FILEBASE_BUCKET=${{ secrets.FILEBASE_BUCKET }} yq e -i '.dfs.filebase.bucket_name = env(FILEBASE_BUCKET)' config.yaml
-          FILEBASE_ENDPOINT=${{ secrets.FILEBASE_ENDPOINT }} yq e -i '.dfs.filebase.endpoint = env(FILEBASE_ENDPOINT)' config.yaml
-          FILEBASE_RESOLVER_URL=${{ secrets.FILEBASE_RESOLVER_URL }} yq e -i '.dfs.filebase.dfs_link_resolver = env(FILEBASE_RESOLVER_URL)' config.yaml
-          # yq e -i '.dfs.storj.type = "uplink"' config.yaml
-          # STORJ_CI_ACCESS_KEY=${{ secrets.STORJ_CI_ACCESS_KEY }} yq e -i '.dfs.storj.access_key = env(STORJ_CI_ACCESS_KEY)' config.yaml
-          # STORJ_CI_SECRET_KEY=${{ secrets.STORJ_CI_SECRET_KEY }} yq e -i '.dfs.storj.secret_key = env(STORJ_CI_SECRET_KEY)' config.yaml
-          # STORJ_CI_BUCKET_NAME=${{ secrets.STORJ_CI_BUCKET_NAME }} yq e -i '.dfs.storj.bucket_name = env(STORJ_CI_BUCKET_NAME)' config.yaml
-          # STORJ_CI_ACCESS_GRANT_TOKEN=${{ secrets.STORJ_CI_ACCESS_GRANT_TOKEN }} yq e -i '.dfs.storj.access_grant_token = env(STORJ_CI_ACCESS_GRANT_TOKEN)' config.yaml
-          # STORJ_CI_ENDPOINT=${{ secrets.STORJ_CI_ENDPOINT }} yq e -i '.dfs.storj.endpoint = env(STORJ_CI_ENDPOINT)' config.yaml
-          # STORJ_CI_RESOLVER_ENDPOINT=${{ secrets.STORJ_CI_RESOLVER_ENDPOINT }} yq e -i '.dfs.storj.dfs_link_resolver = env(STORJ_CI_RESOLVER_ENDPOINT)' config.yaml
-          # STORJ_CI_LINK_SHARE_SERVICE_ENDPOINT=${{ secrets.STORJ_CI_LINK_SHARE_SERVICE_ENDPOINT }} yq e -i '.dfs.storj.link_share_service = env(STORJ_CI_LINK_SHARE_SERVICE_ENDPOINT)' config.yaml
+          yq e -i '.dfs.mock.enabled = "true"' config.yaml
           echo "IP=$IP" >> $GITHUB_ENV
           echo "OCI_ROOT_URL=http://$IP:5000" >> $GITHUB_ENV
           DISTRIBUTION_REF="local-distribution:v$(date +%Y%m%d%H%M%S)"
           docker build -f ./Dockerfile -t "${DISTRIBUTION_REF}" .
           make certs
-          docker run --rm -p 5000:5000 \
+          docker run --rm -p 5000:5000 -p 8080:8080 \
             --mount="type=bind,source=${PWD}/config.yaml,target=/home/runner/.openregistry/config.yaml" \
             -v "$PWD/.certs:/home/runner/.certs" \
             --env="CI_SYS_ADDR=$IP:5000" -d "${DISTRIBUTION_REF}"

--- a/.github/workflows/oci-dist-spec-pull.yml
+++ b/.github/workflows/oci-dist-spec-pull.yml
@@ -53,30 +53,18 @@ jobs:
           yq e -i '.environment = "ci"' config.yaml
           IP=$IP yq e -i '.database.host = env(IP)' config.yaml
           yq e -i '.dfs.mock.enabled = "true"' config.yaml
-          # FILEBASE_KEY=${{ secrets.FILEBASE_KEY }} yq e -i '.dfs.filebase.access_key = env(FILEBASE_KEY)' config.yaml
-          # FILEBASE_SECRET=${{ secrets.FILEBASE_SECRET }} yq e -i '.dfs.filebase.secret_key = env(FILEBASE_SECRET)' config.yaml
-          # FILEBASE_BUCKET=${{ secrets.FILEBASE_BUCKET }} yq e -i '.dfs.filebase.bucket_name = env(FILEBASE_BUCKET)' config.yaml
-          # FILEBASE_ENDPOINT=${{ secrets.FILEBASE_ENDPOINT }} yq e -i '.dfs.filebase.endpoint = env(FILEBASE_ENDPOINT)' config.yaml
-          # FILEBASE_RESOLVER_URL=${{ secrets.FILEBASE_RESOLVER_URL }} yq e -i '.dfs.filebase.dfs_link_resolver = env(FILEBASE_RESOLVER_URL)' config.yaml
-          # yq e -i '.dfs.storj.type = "uplink"' config.yaml
-          # STORJ_CI_ACCESS_KEY=${{ secrets.STORJ_CI_ACCESS_KEY }} yq e -i '.dfs.storj.access_key = env(STORJ_CI_ACCESS_KEY)' config.yaml
-          # STORJ_CI_SECRET_KEY=${{ secrets.STORJ_CI_SECRET_KEY }} yq e -i '.dfs.storj.secret_key = env(STORJ_CI_SECRET_KEY)' config.yaml
-          # STORJ_CI_BUCKET_NAME=${{ secrets.STORJ_CI_BUCKET_NAME }} yq e -i '.dfs.storj.bucket_name = env(STORJ_CI_BUCKET_NAME)' config.yaml
-          # STORJ_CI_ACCESS_GRANT_TOKEN=${{ secrets.STORJ_CI_ACCESS_GRANT_TOKEN }} yq e -i '.dfs.storj.access_grant_token = env(STORJ_CI_ACCESS_GRANT_TOKEN)' config.yaml
-          # STORJ_CI_ENDPOINT=${{ secrets.STORJ_CI_ENDPOINT }} yq e -i '.dfs.storj.endpoint = env(STORJ_CI_ENDPOINT)' config.yaml
-          # STORJ_CI_RESOLVER_ENDPOINT=${{ secrets.STORJ_CI_RESOLVER_ENDPOINT }} yq e -i '.dfs.storj.dfs_link_resolver = env(STORJ_CI_RESOLVER_ENDPOINT)' config.yaml
-          # STORJ_CI_LINK_SHARE_SERVICE_ENDPOINT=${{ secrets.STORJ_CI_LINK_SHARE_SERVICE_ENDPOINT }} yq e -i '.dfs.storj.link_share_service = env(STORJ_CI_LINK_SHARE_SERVICE_ENDPOINT)' config.yaml
           echo "IP=$IP" >> $GITHUB_ENV
           echo "OCI_ROOT_URL=http://$IP:5000" >> $GITHUB_ENV
           DISTRIBUTION_REF="local-distribution:v$(date +%Y%m%d%H%M%S)"
           docker build -f ./Dockerfile -t "${DISTRIBUTION_REF}" .
           make certs
-          docker run --rm -p 5000:5000 \
+          docker run --rm -p 5000:5000 -p 8080:8080 \
             --mount="type=bind,source=${PWD}/config.yaml,target=/home/runner/.openregistry/config.yaml" \
             -v "$PWD/.certs:/home/runner/.certs" \
-            --env="CI_SYS_ADDR=$IP:5000" -d "${DISTRIBUTION_REF}"
+            --env="CI_SYS_ADDR=$IP:5000" --name openregistry -d "${DISTRIBUTION_REF}"
           sleep 5
           curl -XPOST -d ${{ secrets.OPENREGISTRY_SIGNUP_PAYLOAD }} "http://${IP}:5000/auth/signup"
+          docker logs openregistry
       - name: Run OCI Distribution Spec conformance tests
         if: always()
         run: |

--- a/.github/workflows/oci-dist-spec-pull.yml
+++ b/.github/workflows/oci-dist-spec-pull.yml
@@ -52,12 +52,12 @@ jobs:
           cp config.example.yaml config.yaml
           yq e -i '.environment = "ci"' config.yaml
           IP=$IP yq e -i '.database.host = env(IP)' config.yaml
-          yq e -i '.dfs.filebase.enabled = "true"' config.yaml
-          FILEBASE_KEY=${{ secrets.FILEBASE_KEY }} yq e -i '.dfs.filebase.access_key = env(FILEBASE_KEY)' config.yaml
-          FILEBASE_SECRET=${{ secrets.FILEBASE_SECRET }} yq e -i '.dfs.filebase.secret_key = env(FILEBASE_SECRET)' config.yaml
-          FILEBASE_BUCKET=${{ secrets.FILEBASE_BUCKET }} yq e -i '.dfs.filebase.bucket_name = env(FILEBASE_BUCKET)' config.yaml
-          FILEBASE_ENDPOINT=${{ secrets.FILEBASE_ENDPOINT }} yq e -i '.dfs.filebase.endpoint = env(FILEBASE_ENDPOINT)' config.yaml
-          FILEBASE_RESOLVER_URL=${{ secrets.FILEBASE_RESOLVER_URL }} yq e -i '.dfs.filebase.dfs_link_resolver = env(FILEBASE_RESOLVER_URL)' config.yaml
+          yq e -i '.dfs.mock.enabled = "true"' config.yaml
+          # FILEBASE_KEY=${{ secrets.FILEBASE_KEY }} yq e -i '.dfs.filebase.access_key = env(FILEBASE_KEY)' config.yaml
+          # FILEBASE_SECRET=${{ secrets.FILEBASE_SECRET }} yq e -i '.dfs.filebase.secret_key = env(FILEBASE_SECRET)' config.yaml
+          # FILEBASE_BUCKET=${{ secrets.FILEBASE_BUCKET }} yq e -i '.dfs.filebase.bucket_name = env(FILEBASE_BUCKET)' config.yaml
+          # FILEBASE_ENDPOINT=${{ secrets.FILEBASE_ENDPOINT }} yq e -i '.dfs.filebase.endpoint = env(FILEBASE_ENDPOINT)' config.yaml
+          # FILEBASE_RESOLVER_URL=${{ secrets.FILEBASE_RESOLVER_URL }} yq e -i '.dfs.filebase.dfs_link_resolver = env(FILEBASE_RESOLVER_URL)' config.yaml
           # yq e -i '.dfs.storj.type = "uplink"' config.yaml
           # STORJ_CI_ACCESS_KEY=${{ secrets.STORJ_CI_ACCESS_KEY }} yq e -i '.dfs.storj.access_key = env(STORJ_CI_ACCESS_KEY)' config.yaml
           # STORJ_CI_SECRET_KEY=${{ secrets.STORJ_CI_SECRET_KEY }} yq e -i '.dfs.storj.secret_key = env(STORJ_CI_SECRET_KEY)' config.yaml

--- a/.github/workflows/oci-dist-spec-push.yml
+++ b/.github/workflows/oci-dist-spec-push.yml
@@ -57,26 +57,13 @@ jobs:
           cp config.example.yaml config.yaml
           yq e -i '.environment = "ci"' config.yaml
           IP=$IP yq e -i '.database.host = env(IP)' config.yaml
-          yq e -i '.dfs.filebase.enabled = "true"' config.yaml
-          FILEBASE_KEY=${{ secrets.FILEBASE_KEY }} yq e -i '.dfs.filebase.access_key = env(FILEBASE_KEY)' config.yaml
-          FILEBASE_SECRET=${{ secrets.FILEBASE_SECRET }} yq e -i '.dfs.filebase.secret_key = env(FILEBASE_SECRET)' config.yaml
-          FILEBASE_BUCKET=${{ secrets.FILEBASE_BUCKET }} yq e -i '.dfs.filebase.bucket_name = env(FILEBASE_BUCKET)' config.yaml
-          FILEBASE_ENDPOINT=${{ secrets.FILEBASE_ENDPOINT }} yq e -i '.dfs.filebase.endpoint = env(FILEBASE_ENDPOINT)' config.yaml
-          FILEBASE_RESOLVER_URL=${{ secrets.FILEBASE_RESOLVER_URL }} yq e -i '.dfs.filebase.dfs_link_resolver = env(FILEBASE_RESOLVER_URL)' config.yaml
-          # yq e -i '.dfs.storj.type = "uplink"' config.yaml
-          # STORJ_CI_ACCESS_KEY=${{ secrets.STORJ_CI_ACCESS_KEY }} yq e -i '.dfs.storj.access_key = env(STORJ_CI_ACCESS_KEY)' config.yaml
-          # STORJ_CI_SECRET_KEY=${{ secrets.STORJ_CI_SECRET_KEY }} yq e -i '.dfs.storj.secret_key = env(STORJ_CI_SECRET_KEY)' config.yaml
-          # STORJ_CI_BUCKET_NAME=${{ secrets.STORJ_CI_BUCKET_NAME }} yq e -i '.dfs.storj.bucket_name = env(STORJ_CI_BUCKET_NAME)' config.yaml
-          # STORJ_CI_ACCESS_GRANT_TOKEN=${{ secrets.STORJ_CI_ACCESS_GRANT_TOKEN }} yq e -i '.dfs.storj.access_grant_token = env(STORJ_CI_ACCESS_GRANT_TOKEN)' config.yaml
-          # STORJ_CI_ENDPOINT=${{ secrets.STORJ_CI_ENDPOINT }} yq e -i '.dfs.storj.endpoint = env(STORJ_CI_ENDPOINT)' config.yaml
-          # STORJ_CI_RESOLVER_ENDPOINT=${{ secrets.STORJ_CI_RESOLVER_ENDPOINT }} yq e -i '.dfs.storj.dfs_link_resolver = env(STORJ_CI_RESOLVER_ENDPOINT)' config.yaml
-          # STORJ_CI_LINK_SHARE_SERVICE_ENDPOINT=${{ secrets.STORJ_CI_LINK_SHARE_SERVICE_ENDPOINT }} yq e -i '.dfs.storj.link_share_service = env(STORJ_CI_LINK_SHARE_SERVICE_ENDPOINT)' config.yaml
+          yq e -i '.dfs.mock.enabled = "true"' config.yaml
           echo "IP=$IP" >> $GITHUB_ENV
           echo "OCI_ROOT_URL=http://$IP:5000" >> $GITHUB_ENV
           DISTRIBUTION_REF="local-distribution:v$(date +%Y%m%d%H%M%S)"
           docker build -f ./Dockerfile -t "${DISTRIBUTION_REF}" .
           make certs
-          docker run --rm -p 5000:5000 \
+          docker run --rm -p 5000:5000 -p 8080:8080 \
             --mount="type=bind,source=${PWD}/config.yaml,target=/home/runner/.openregistry/config.yaml" \
             -v "$PWD/.certs:/home/runner/.certs" \
             --env="CI_SYS_ADDR=$IP:5000" --name openregistry -d "${DISTRIBUTION_REF}"

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -30,6 +30,14 @@ oauth:
     client_id: dummy-gh-client-id
     client_secret: dummy-gh-client-secret
 dfs:
+  mock:
+    enabled: true
+    type: "s3"
+    access_key: <access-key>
+    secret_key: <access-secret-key>
+    endpoint: <s3-compatible-api-endpoint>
+    bucket_name: <s3-bucket-name>
+    dfs_link_resolver: <optional-dfs-link-resolver-url>
   filebase:
     enabled: false
     type: "s3"

--- a/config/config.go
+++ b/config/config.go
@@ -43,6 +43,7 @@ type (
 	DFS struct {
 		Filebase S3CompatibleDFS `yaml:"filebase" mapstructure:"filebase"`
 		Storj    Storj           `yaml:"storj" mapstructure:"storj"`
+		Mock     S3CompatibleDFS `yaml:"mock" mapstructure:"mock"`
 	}
 
 	Storj struct {

--- a/dfs/client/client.go
+++ b/dfs/client/client.go
@@ -6,6 +6,7 @@ import (
 	"github.com/containerish/OpenRegistry/config"
 	"github.com/containerish/OpenRegistry/dfs"
 	"github.com/containerish/OpenRegistry/dfs/filebase"
+	"github.com/containerish/OpenRegistry/dfs/mock"
 	"github.com/containerish/OpenRegistry/dfs/storj"
 	"github.com/containerish/OpenRegistry/dfs/storj/uplink"
 	"github.com/fatih/color"
@@ -27,6 +28,11 @@ func NewDFSBackend(env config.Environment, cfg *config.DFS) dfs.DFS {
 	if cfg.Storj.Enabled && cfg.Storj.Type == "uplink" {
 		color.Green("Storage backend: Storj with Uplink")
 		return uplink.New(env, &cfg.Storj)
+	}
+
+	if cfg.Mock.Enabled {
+		color.Green("Storage backend: Mock Storage")
+		return mock.NewMockStorage(env, &cfg.Mock)
 	}
 
 	log.Fatalln(color.RedString("no supported storage backend is enabled"))

--- a/dfs/client/client.go
+++ b/dfs/client/client.go
@@ -14,7 +14,7 @@ import (
 
 // NewDFSBackend returns the first enabled DFS for OpenRegistry.
 // It tries for all the possible backends and returns the first one that's enabled.
-func NewDFSBackend(env config.Environment, cfg *config.DFS) dfs.DFS {
+func NewDFSBackend(env config.Environment, registryEndpoint string, cfg *config.DFS) dfs.DFS {
 	if cfg.Filebase.Enabled {
 		color.Green("Storage backend: Filebase")
 		return filebase.New(env, &cfg.Filebase)
@@ -32,7 +32,7 @@ func NewDFSBackend(env config.Environment, cfg *config.DFS) dfs.DFS {
 
 	if cfg.Mock.Enabled {
 		color.Green("Storage backend: Mock Storage")
-		return mock.NewMockStorage(env, &cfg.Mock)
+		return mock.NewMockStorage(env, registryEndpoint, &cfg.Mock)
 	}
 
 	log.Fatalln(color.RedString("no supported storage backend is enabled"))

--- a/dfs/mock/storage.go
+++ b/dfs/mock/storage.go
@@ -13,6 +13,7 @@ import (
 	"github.com/containerish/OpenRegistry/config"
 	"github.com/containerish/OpenRegistry/dfs"
 	"github.com/containerish/OpenRegistry/types"
+	"github.com/fatih/color"
 	"github.com/google/uuid"
 	"github.com/labstack/echo/v4"
 	"github.com/spf13/afero"
@@ -183,7 +184,9 @@ func (ms *mockStorage) FileServer() {
 		return ctx.Blob(http.StatusOK, "", bz)
 	})
 
-	e.Start(ms.serverEndpoint)
+	if err := e.Start(ms.serverEndpoint); err != nil {
+		color.Red("MockStorage service failed: %s", err)
+	}
 }
 
 type mockStorage struct {

--- a/dfs/mock/storage.go
+++ b/dfs/mock/storage.go
@@ -1,0 +1,211 @@
+package mock
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"strings"
+
+	skynet "github.com/SkynetLabs/go-skynet/v2"
+	s3types "github.com/aws/aws-sdk-go-v2/service/s3/types"
+	"github.com/containerish/OpenRegistry/config"
+	"github.com/containerish/OpenRegistry/dfs"
+	"github.com/containerish/OpenRegistry/types"
+	"github.com/google/uuid"
+	"github.com/labstack/echo/v4"
+	"github.com/spf13/afero"
+)
+
+func (ms *mockStorage) CreateMultipartUpload(layerKey string) (string, error) {
+	sessionId := uuid.NewString()
+	ms.uploadSession[sessionId] = sessionId
+	return sessionId, nil
+}
+
+func (ms *mockStorage) UploadPart(
+	ctx context.Context,
+	uploadId string,
+	layerKey string,
+	digest string,
+	partNumber int64,
+	content io.ReadSeeker,
+	contentLength int64,
+) (s3types.CompletedPart, error) {
+	fd, err := ms.memFs.OpenFile(layerKey, os.O_RDWR|os.O_CREATE, os.ModePerm)
+	if err != nil {
+		return s3types.CompletedPart{}, err
+	}
+
+	bz, _ := io.ReadAll(content)
+	if _, err = fd.Write(bz); err != nil {
+		return s3types.CompletedPart{}, err
+	}
+	if err = fd.Sync(); err != nil {
+		return s3types.CompletedPart{}, err
+	}
+	fd.Close()
+
+	return s3types.CompletedPart{
+		ChecksumCRC32:  &digest,
+		ChecksumCRC32C: &layerKey,
+		PartNumber:     int32(partNumber),
+	}, nil
+}
+
+func (ms *mockStorage) CompleteMultipartUpload(
+	ctx context.Context,
+	uploadId string,
+	layerKey string,
+	layerDigest string,
+	completedParts []s3types.CompletedPart,
+) (string, error) {
+	delete(ms.uploadSession, layerKey)
+	return layerKey, nil
+}
+
+func (ms *mockStorage) Upload(ctx context.Context, identifier, digest string, content []byte) (string, error) {
+	fd, err := ms.memFs.Create(identifier)
+	if err != nil {
+		return "", err
+	}
+
+	bz, _ := io.ReadAll(fd)
+	if _, err = fd.Write(bz); err != nil {
+		return "", err
+	}
+	if err = fd.Sync(); err != nil {
+		return "", err
+	}
+	fd.Close()
+
+	return identifier, nil
+}
+
+func (ms *mockStorage) Download(ctx context.Context, path string) (io.ReadCloser, error) {
+	fd, err := ms.memFs.Open(path)
+	if err != nil {
+		return nil, err
+	}
+
+	return fd, nil
+}
+
+func (ms *mockStorage) DownloadDir(skynetLink, dir string) error {
+	return nil
+}
+
+func (ms *mockStorage) List(path string) ([]*types.Metadata, error) {
+	return nil, nil
+}
+
+func (ms *mockStorage) AddImage(ns string, mf, l map[string][]byte) (string, error) {
+	return "", nil
+}
+
+func (ms *mockStorage) Metadata(identifier string) (*skynet.Metadata, error) {
+	fd, err := ms.memFs.Open(identifier)
+	if err != nil {
+		return nil, err
+	}
+
+	stat, err := fd.Stat()
+	if err != nil {
+		return nil, err
+	}
+	fd.Close()
+
+	return &skynet.Metadata{
+		ContentType:   "",
+		Etag:          "",
+		Skylink:       identifier,
+		ContentLength: int(stat.Size()),
+	}, nil
+
+}
+
+func (ms *mockStorage) GetUploadProgress(identifier, uploadID string) (*types.ObjectMetadata, error) {
+	fd, err := ms.memFs.Open(identifier)
+	if err != nil {
+		return nil, err
+	}
+
+	stat, err := fd.Stat()
+	if err != nil {
+		return nil, err
+	}
+
+	return &types.ObjectMetadata{
+		ContentLength: int(stat.Size()),
+	}, nil
+}
+
+func (ms *mockStorage) GeneratePresignedURL(ctx context.Context, key string) (string, error) {
+	parts := strings.Split(key, "/")
+	if len(parts) == 1 {
+		key = "layers/" + key
+	}
+
+	preSignedURL := fmt.Sprintf("http://%s/%s", ms.serverEndpoint, key)
+	return preSignedURL, nil
+}
+
+func (ms *mockStorage) AbortMultipartUpload(ctx context.Context, layerKey string, uploadId string) error {
+	if err := ms.memFs.Remove(layerKey); err != nil {
+		return err
+	}
+
+	delete(ms.uploadSession, uploadId)
+	return nil
+}
+
+func (ms *mockStorage) Config() *config.S3CompatibleDFS {
+	return ms.config
+}
+
+func (ms *mockStorage) FileServer() {
+	e := echo.New()
+	e.HideBanner = true
+	e.HidePort = true
+
+	e.Add(http.MethodGet, "/:uuid", func(ctx echo.Context) error {
+		fileID := ctx.Param("uuid")
+		fd, err := ms.memFs.Open(fileID)
+		if err != nil {
+			return ctx.JSON(http.StatusBadRequest, echo.Map{
+				"error": err.Error(),
+			})
+		}
+
+		bz, _ := io.ReadAll(fd)
+		fd.Close()
+		return ctx.Blob(http.StatusOK, "", bz)
+	})
+
+	e.Start(ms.serverEndpoint)
+}
+
+type mockStorage struct {
+	memFs          afero.Fs
+	uploadSession  map[string]string
+	config         *config.S3CompatibleDFS
+	serverEndpoint string
+}
+
+func NewMockStorage(env config.Environment, cfg *config.S3CompatibleDFS) dfs.DFS {
+	if env != config.CI && env != config.Local {
+		panic("mock storage should only be used for CI or Local environments")
+	}
+
+	mocker := &mockStorage{
+		memFs:          afero.NewMemMapFs(),
+		uploadSession:  make(map[string]string),
+		config:         cfg,
+		serverEndpoint: "0.0.0.0:8080",
+	}
+
+	go mocker.FileServer()
+
+	return mocker
+}

--- a/go.sum
+++ b/go.sum
@@ -42,6 +42,8 @@ github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym
 github.com/Masterminds/semver/v3 v3.1.1/go.mod h1:VPu/7SZ7ePZ3QOrcuXROw5FAcLl4a0cBrbBpGY/8hQs=
 github.com/ProtonMail/go-crypto v0.0.0-20230217124315-7d5c6f04bbb8 h1:wPbRQzjjwFc0ih8puEVAOFGELsn1zoIIYdxvML7mDxA=
 github.com/ProtonMail/go-crypto v0.0.0-20230217124315-7d5c6f04bbb8/go.mod h1:I0gYDMZ6Z5GRU7l58bNFSkPTFN6Yl12dsUlAZ8xy98g=
+github.com/alecthomas/template v0.0.0-20190718012654-fb15b899a751/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
+github.com/alecthomas/units v0.0.0-20190924025748-f65c72e2690d/go.mod h1:rBZYJk541a8SKzHPHnH3zbiI+7dagKZ0cgpgrD7Fyho=
 github.com/alexliesenfeld/health v0.7.0 h1:U3mSZ3ussRbGx+/rXBjNVxjLX5cKaNh8Ly9Hx3q+yfY=
 github.com/alexliesenfeld/health v0.7.0/go.mod h1:6Nnjbu7vBYHoZqIuZeOnTpnW7OH14ulR+wIBE2QuJ8I=
 github.com/aws/aws-sdk-go-v2 v1.19.0 h1:klAT+y3pGFBU/qVf1uzwttpBbiuozJYWzNLHioyDJ+k=
@@ -134,6 +136,7 @@ github.com/go-gl/glfw/v3.3/glfw v0.0.0-20191125211704-12ad95a8df72/go.mod h1:tQ2
 github.com/go-gl/glfw/v3.3/glfw v0.0.0-20200222043503-6f7a984d4dc4/go.mod h1:tQ2UAYgL5IevRw8kRxooKSPJfGvJ9fJQFa0TUsXzTg8=
 github.com/go-kit/log v0.1.0/go.mod h1:zbhenjAZHb184qTLMA9ZjW7ThYL0H2mk7Q6pNt4vbaY=
 github.com/go-logfmt/logfmt v0.5.0/go.mod h1:wCYkCAKZfumFQihp8CzCvQ3paCTfi41vtzG1KdI/P7A=
+github.com/go-logfmt/logfmt v0.5.1/go.mod h1:WYhtIu8zTZfxdn5+rREduYbwxfcBr/Vr6KEVveWlfTs=
 github.com/go-playground/assert/v2 v2.2.0 h1:JvknZsQTYeFEAhQwI4qEt9cyV5ONwRHC+lYKSsYSR8s=
 github.com/go-playground/locales v0.14.1 h1:EWaQ/wswjilfKLTECiXz7Rh+3BjFhfDFKv/oXslEjJA=
 github.com/go-playground/locales v0.14.1/go.mod h1:hxrqLVvrK65+Rwrd5Fc6F2O76J/NuW9t0sjnWqG1slY=
@@ -295,12 +298,14 @@ github.com/jackc/puddle v1.3.0 h1:eHK/5clGOatcjX3oWGBO/MpxpbHzSwud5EWTSCI+MX0=
 github.com/jackc/puddle v1.3.0/go.mod h1:m4B5Dj62Y0fbyuIc15OsIqK0+JU8nkqQjsgx7dvjSWk=
 github.com/jmespath/go-jmespath v0.4.0/go.mod h1:T8mJZnbsbmF+m6zOOFylbeCJqk5+pHWvzYPziyZiYoo=
 github.com/jmespath/go-jmespath/internal/testify v1.5.1/go.mod h1:L3OGu8Wl2/fWfCI6z80xFu9LTZmf1ZRjMHUOPmWr69U=
+github.com/jpillora/backoff v1.0.0/go.mod h1:J/6gKK9jxlEcS3zixgDgUAsiuZ7yrSoa/FX5e0EB2j4=
 github.com/json-iterator/go v1.1.12 h1:PV8peI4a0ysnczrg+LtxykD8LfKY9ML6u2jnxaEnrnM=
 github.com/json-iterator/go v1.1.12/go.mod h1:e30LSqwooZae/UwlEbR2852Gd8hjQvJoHmT4TnhNGBo=
 github.com/jstemmer/go-junit-report v0.0.0-20190106144839-af01ea7f8024/go.mod h1:6v2b51hI/fHJwM22ozAgKL4VKDeJcHhJFhtBdhmNjmU=
 github.com/jstemmer/go-junit-report v0.9.1/go.mod h1:Brl9GWCQeLvo8nXZwPNNblvFj/XSXhF0NWZEnDohbsk=
 github.com/jtolio/eventkit v0.0.0-20221004135224-074cf276595b h1:tO4MX3k5bvV0Sjv5jYrxStMTJxf1m/TW24XRyHji4aU=
 github.com/jtolio/eventkit v0.0.0-20221004135224-074cf276595b/go.mod h1:q7yMR8BavTz/gBNtIT/uF487LMgcuEpNGKISLAjNQes=
+github.com/julienschmidt/httprouter v1.3.0/go.mod h1:JR6WtHb+2LUe8TCKY3cZOxFyyO8IZAc4RVcycCCAKdM=
 github.com/kisielk/errcheck v1.5.0/go.mod h1:pFxgyoBC7bSaBwPgfKdkLd5X25qrDl4LWUI2bnpBCr8=
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=
 github.com/klauspost/cpuid/v2 v2.0.12 h1:p9dKCg8i4gmOxtv35DvrYoWqYzQrvEVdjQ762Y0OqZE=
@@ -353,6 +358,7 @@ github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd h1:TRLaZ9cD/w
 github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=
 github.com/modern-go/reflect2 v1.0.2 h1:xBagoLtFs94CBntxluKeaWgTMpvLxC4ur3nMaC9Gz0M=
 github.com/modern-go/reflect2 v1.0.2/go.mod h1:yWuevngMOJpCy52FWWMvUC8ws7m/LJsjYzDa0/r8luk=
+github.com/mwitkow/go-conntrack v0.0.0-20190716064945-2f068394615f/go.mod h1:qRWi+5nqEBWmkhHvq77mSJWrCKwh8bxhgT7d/eI7P4U=
 github.com/nbio/st v0.0.0-20140626010706-e9e8d9816f32/go.mod h1:9wM+0iRr9ahx58uYLpLIr5fm8diHn0JbqRycJi6w0Ms=
 github.com/opencontainers/distribution-spec v1.0.1 h1:hT6tF6uKZAQh+HH3BrJqn7/xHhMoDHzahIg4KxD2DqM=
 github.com/opencontainers/distribution-spec v1.0.1/go.mod h1:copR2flp+jTEvQIFMb6MIx45OkrxzqyjszPDT3hx/5Q=
@@ -827,6 +833,7 @@ google.golang.org/protobuf v1.26.0/go.mod h1:9q0QmTI4eRPtz6boOQmLYwt+qCgq0jsYwAQ
 google.golang.org/protobuf v1.28.0/go.mod h1:HV8QOd/L58Z+nl8r43ehVNZIU/HEI6OcFqwMG9pJV4I=
 google.golang.org/protobuf v1.31.0 h1:g0LDEJHgrBl9N9r17Ru3sqWhkIx2NB67okBHPwC7hs8=
 google.golang.org/protobuf v1.31.0/go.mod h1:HV8QOd/L58Z+nl8r43ehVNZIU/HEI6OcFqwMG9pJV4I=
+gopkg.in/alecthomas/kingpin.v2 v2.2.6/go.mod h1:FMv+mEhP44yOT+4EoQTLFTRgOQ1FBLkstjWtayDeSgw=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c h1:Hei/4ADfdWqJk1ZMxUNpqntNwaWcugrBjAiHlqqRiVk=

--- a/main.go
+++ b/main.go
@@ -58,7 +58,7 @@ func main() {
 	webauthnServer := auth_server.NewWebauthnServer(cfg, pgStore, logger)
 	healthCheckHandler := healthchecks.NewHealthChecksAPI(pgStore)
 
-	dfs := client.NewDFSBackend(cfg.Environment, &cfg.DFS)
+	dfs := client.NewDFSBackend(cfg.Environment, cfg.Endpoint(), &cfg.DFS)
 	reg, err := registry.NewRegistry(pgStore, dfs, logger, cfg)
 	if err != nil {
 		e.Logger.Errorf("error creating new container registry: %s", err)


### PR DESCRIPTION
### Motivation & Context:

This PR adds a mock storage driver for OCI backend. The mock storage implementation uses an in-memory storage provided by [afero](https://github.com/spf13/afero)

### Description:

The actual storage drivers (like Storj, Filebase, and S3) are all real storage backends & they require some maintenance, like:

1. Provision buckets/resources for CI envirionment
2. Setting policies for automatic deletion for objects
3. Deletion for multipart-aborted uploads
4. Costs

With this **Mock Storage Driver** we don't have to maintain any resources & costs. This is an in-memory storage implementation which gets purged as soon as the app exits.

### Types of Changes:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### PR Checklist:

- [x] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [x] I've read the CONTRIBUTION guide
- [x] I have signed-off my commits with git commit -s
